### PR TITLE
feat: Add automatic standard CI variable resolution

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -94,3 +94,85 @@ jobs:
           echo "  is_prod: ${{ fromJSON(steps.test-vars.outputs.all).is_prod }}"
           echo "  computed_name: ${{ fromJSON(steps.test-vars.outputs.all).computed_name }}"
           echo "  port_number: ${{ fromJSON(steps.test-vars.outputs.all).port_number }}"
+
+  test-standard-ci-vars:
+    name: Test Standard CI Variables
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Test standard CI vars enabled
+        id: test-ci-vars
+        uses: ./
+        with:
+          standard_ci_vars: true
+          log_outputs: true
+          static_inputs: |
+            custom_var=test_value
+
+      - name: Print CI variables output
+        run: |
+          echo "=== DEBUG: Standard CI Variables ==="
+          echo "All variables: ${{ steps.test-ci-vars.outputs.all }}"
+          echo "Repository: ${{ steps.test-ci-vars.outputs.repo }}"
+          echo "Trigger type: ${{ steps.test-ci-vars.outputs.trigger-type }}"
+          echo "Actor: ${{ steps.test-ci-vars.outputs.actor }}"
+          echo "=================================="
+
+      - name: Verify standard CI variables
+        run: |
+          # Check that standard CI variables are populated
+          if [ -z "${{ steps.test-ci-vars.outputs.repo }}" ]; then
+            echo "ERROR: repo variable should be populated"
+            exit 1
+          fi
+
+          if [ -z "${{ steps.test-ci-vars.outputs.trigger-type }}" ]; then
+            echo "ERROR: trigger-type variable should be populated"
+            exit 1
+          fi
+
+          if [ -z "${{ steps.test-ci-vars.outputs.actor }}" ]; then
+            echo "ERROR: actor variable should be populated"
+            exit 1
+          fi
+
+          # Verify repo matches expected format
+          if [ "${{ steps.test-ci-vars.outputs.repo }}" != "aaronsteers/resolve-vars-action" ]; then
+            echo "ERROR: repo should be aaronsteers/resolve-vars-action"
+            echo "Actual: ${{ steps.test-ci-vars.outputs.repo }}"
+            exit 1
+          fi
+
+          # Check that custom variables are still included
+          if [ "${{ fromJSON(steps.test-ci-vars.outputs.all).custom_var }}" != "test_value" ]; then
+            echo "ERROR: custom_var should still be included with standard CI vars"
+            exit 1
+          fi
+
+          echo "✅ Standard CI variables test passed!"
+
+      - name: Test standard CI vars disabled (backward compatibility)
+        id: test-no-ci-vars
+        uses: ./
+        with:
+          standard_ci_vars: false
+          static_inputs: |
+            test_var=backward_compat
+
+      - name: Verify backward compatibility
+        run: |
+          # Ensure CI variables are NOT populated when disabled
+          if [ -n "${{ steps.test-no-ci-vars.outputs.repo }}" ]; then
+            echo "ERROR: repo should not be populated when standard_ci_vars is false"
+            exit 1
+          fi
+
+          # Ensure custom variables still work
+          if [ "${{ fromJSON(steps.test-no-ci-vars.outputs.all).test_var }}" != "backward_compat" ]; then
+            echo "ERROR: custom variables should still work when standard_ci_vars is false"
+            exit 1
+          fi
+
+          echo "✅ Backward compatibility test passed!"

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -106,7 +106,6 @@ jobs:
         id: test-ci-vars
         uses: ./
         with:
-          standard_ci_vars: true
           log_outputs: true
           static_inputs: |
             custom_var=test_value
@@ -115,9 +114,13 @@ jobs:
         run: |
           echo "=== DEBUG: Standard CI Variables ==="
           echo "All variables: ${{ steps.test-ci-vars.outputs.all }}"
-          echo "Repository: ${{ steps.test-ci-vars.outputs.repo }}"
+          echo "Target repo: ${{ steps.test-ci-vars.outputs.repo }}"
           echo "Trigger type: ${{ steps.test-ci-vars.outputs.trigger-type }}"
           echo "Actor: ${{ steps.test-ci-vars.outputs.actor }}"
+          echo "Repo owner: ${{ steps.test-ci-vars.outputs.repo-owner }}"
+          echo "Repository name: ${{ steps.test-ci-vars.outputs.repo-name }}"
+          echo "Repository name full: ${{ steps.test-ci-vars.outputs.repo-name-full }}"
+          echo "Restricted security mode: ${{ steps.test-ci-vars.outputs.restricted-security-mode }}"
           echo "=================================="
 
       - name: Verify standard CI variables
@@ -138,10 +141,58 @@ jobs:
             exit 1
           fi
 
+          if [ -z "${{ steps.test-ci-vars.outputs.repo-owner }}" ]; then
+            echo "ERROR: repo-owner variable should be populated"
+            exit 1
+          fi
+
+          if [ -z "${{ steps.test-ci-vars.outputs.repo-name }}" ]; then
+            echo "ERROR: repo-name variable should be populated"
+            exit 1
+          fi
+
+          if [ -z "${{ steps.test-ci-vars.outputs.repo-name-full }}" ]; then
+            echo "ERROR: repo-name-full variable should be populated"
+            exit 1
+          fi
+
+          if [ -z "${{ steps.test-ci-vars.outputs.restricted-security-mode }}" ]; then
+            echo "ERROR: restricted-security-mode variable should be populated"
+            exit 1
+          fi
+
           # Verify repo matches expected format
           if [ "${{ steps.test-ci-vars.outputs.repo }}" != "aaronsteers/resolve-vars-action" ]; then
             echo "ERROR: repo should be aaronsteers/resolve-vars-action"
             echo "Actual: ${{ steps.test-ci-vars.outputs.repo }}"
+            exit 1
+          fi
+
+          # Verify repo-owner matches expected value
+          if [ "${{ steps.test-ci-vars.outputs.repo-owner }}" != "aaronsteers" ]; then
+            echo "ERROR: repo-owner should be aaronsteers"
+            echo "Actual: ${{ steps.test-ci-vars.outputs.repo-owner }}"
+            exit 1
+          fi
+
+          # Verify repo-name matches expected value
+          if [ "${{ steps.test-ci-vars.outputs.repo-name }}" != "resolve-vars-action" ]; then
+            echo "ERROR: repo-name should be resolve-vars-action"
+            echo "Actual: ${{ steps.test-ci-vars.outputs.repo-name }}"
+            exit 1
+          fi
+
+          # Verify repo-name-full matches expected value
+          if [ "${{ steps.test-ci-vars.outputs.repo-name-full }}" != "aaronsteers/resolve-vars-action" ]; then
+            echo "ERROR: repo-name-full should be aaronsteers/resolve-vars-action"
+            echo "Actual: ${{ steps.test-ci-vars.outputs.repo-name-full }}"
+            exit 1
+          fi
+
+          # Verify restricted-security-mode is false for non-fork PRs
+          if [ "${{ steps.test-ci-vars.outputs.restricted-security-mode }}" != "false" ]; then
+            echo "ERROR: restricted-security-mode should be false for non-fork PRs"
+            echo "Actual: ${{ steps.test-ci-vars.outputs.restricted-security-mode }}"
             exit 1
           fi
 

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -114,7 +114,7 @@ jobs:
         run: |
           echo "=== DEBUG: Standard CI Variables ==="
           echo "All variables: ${{ steps.test-ci-vars.outputs.custom }}"
-          echo "Resolved repo: ${{ steps.test-ci-vars.outputs.resolved-repo-full-name }}"
+          echo "Resolved repo: ${{ steps.test-ci-vars.outputs.resolved-repo-name-full }}"
           echo "Resolved branch: ${{ steps.test-ci-vars.outputs.resolved-git-branch }}"
           echo "PR number: ${{ steps.test-ci-vars.outputs.pr-number }}"
           echo "Run ID: ${{ steps.test-ci-vars.outputs.run-id }}"
@@ -124,8 +124,8 @@ jobs:
       - name: Verify standard CI variables
         run: |
           # Check that standard CI variables are populated
-          if [ -z "${{ steps.test-ci-vars.outputs.resolved-repo-full-name }}" ]; then
-            echo "ERROR: resolved-repo-full-name variable should be populated"
+          if [ -z "${{ steps.test-ci-vars.outputs.resolved-repo-name-full }}" ]; then
+            echo "ERROR: resolved-repo-name-full variable should be populated"
             exit 1
           fi
 
@@ -154,10 +154,10 @@ jobs:
             exit 1
           fi
 
-          # Verify resolved-repo-full-name matches expected format
-          if [ "${{ steps.test-ci-vars.outputs.resolved-repo-full-name }}" != "aaronsteers/resolve-vars-action" ]; then
-            echo "ERROR: resolved-repo-full-name should be aaronsteers/resolve-vars-action"
-            echo "Actual: ${{ steps.test-ci-vars.outputs.resolved-repo-full-name }}"
+          # Verify resolved-repo-name-full matches expected format
+          if [ "${{ steps.test-ci-vars.outputs.resolved-repo-name-full }}" != "aaronsteers/resolve-vars-action" ]; then
+            echo "ERROR: resolved-repo-name-full should be aaronsteers/resolve-vars-action"
+            echo "Actual: ${{ steps.test-ci-vars.outputs.resolved-repo-name-full }}"
             exit 1
           fi
 

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -113,91 +113,77 @@ jobs:
       - name: Print CI variables output
         run: |
           echo "=== DEBUG: Standard CI Variables ==="
-          echo "All variables: ${{ steps.test-ci-vars.outputs.all }}"
-          echo "Target repo: ${{ steps.test-ci-vars.outputs.repo }}"
-          echo "Trigger type: ${{ steps.test-ci-vars.outputs.trigger-type }}"
-          echo "Actor: ${{ steps.test-ci-vars.outputs.actor }}"
-          echo "Repo owner: ${{ steps.test-ci-vars.outputs.repo-owner }}"
-          echo "Repository name: ${{ steps.test-ci-vars.outputs.repo-name }}"
-          echo "Repository name full: ${{ steps.test-ci-vars.outputs.repo-name-full }}"
-          echo "Restricted security mode: ${{ steps.test-ci-vars.outputs.restricted-security-mode }}"
+          echo "All variables: ${{ steps.test-ci-vars.outputs.custom }}"
+          echo "Resolved repo: ${{ steps.test-ci-vars.outputs.resolved-repo-full-name }}"
+          echo "Resolved branch: ${{ steps.test-ci-vars.outputs.resolved-git-branch }}"
+          echo "PR number: ${{ steps.test-ci-vars.outputs.pr-number }}"
+          echo "Run ID: ${{ steps.test-ci-vars.outputs.run-id }}"
+          echo "Is PR: ${{ steps.test-ci-vars.outputs.is-pr }}"
           echo "=================================="
 
       - name: Verify standard CI variables
         run: |
           # Check that standard CI variables are populated
-          if [ -z "${{ steps.test-ci-vars.outputs.repo }}" ]; then
-            echo "ERROR: repo variable should be populated"
+          if [ -z "${{ steps.test-ci-vars.outputs.resolved-repo-full-name }}" ]; then
+            echo "ERROR: resolved-repo-full-name variable should be populated"
             exit 1
           fi
 
-          if [ -z "${{ steps.test-ci-vars.outputs.trigger-type }}" ]; then
-            echo "ERROR: trigger-type variable should be populated"
+          if [ -z "${{ steps.test-ci-vars.outputs.resolved-git-branch }}" ]; then
+            echo "ERROR: resolved-git-branch variable should be populated"
             exit 1
           fi
 
-          if [ -z "${{ steps.test-ci-vars.outputs.actor }}" ]; then
-            echo "ERROR: actor variable should be populated"
+          if [ -z "${{ steps.test-ci-vars.outputs.resolved-repo-owner }}" ]; then
+            echo "ERROR: resolved-repo-owner variable should be populated"
             exit 1
           fi
 
-          if [ -z "${{ steps.test-ci-vars.outputs.repo-owner }}" ]; then
-            echo "ERROR: repo-owner variable should be populated"
+          if [ -z "${{ steps.test-ci-vars.outputs.resolved-repo-name }}" ]; then
+            echo "ERROR: resolved-repo-name variable should be populated"
             exit 1
           fi
 
-          if [ -z "${{ steps.test-ci-vars.outputs.repo-name }}" ]; then
-            echo "ERROR: repo-name variable should be populated"
+          if [ -z "${{ steps.test-ci-vars.outputs.run-id }}" ]; then
+            echo "ERROR: run-id variable should be populated"
             exit 1
           fi
 
-          if [ -z "${{ steps.test-ci-vars.outputs.repo-name-full }}" ]; then
-            echo "ERROR: repo-name-full variable should be populated"
+          if [ -z "${{ steps.test-ci-vars.outputs.is-pr }}" ]; then
+            echo "ERROR: is-pr variable should be populated"
             exit 1
           fi
 
-          if [ -z "${{ steps.test-ci-vars.outputs.restricted-security-mode }}" ]; then
-            echo "ERROR: restricted-security-mode variable should be populated"
+          # Verify resolved-repo-full-name matches expected format
+          if [ "${{ steps.test-ci-vars.outputs.resolved-repo-full-name }}" != "aaronsteers/resolve-vars-action" ]; then
+            echo "ERROR: resolved-repo-full-name should be aaronsteers/resolve-vars-action"
+            echo "Actual: ${{ steps.test-ci-vars.outputs.resolved-repo-full-name }}"
             exit 1
           fi
 
-          # Verify repo matches expected format
-          if [ "${{ steps.test-ci-vars.outputs.repo }}" != "aaronsteers/resolve-vars-action" ]; then
-            echo "ERROR: repo should be aaronsteers/resolve-vars-action"
-            echo "Actual: ${{ steps.test-ci-vars.outputs.repo }}"
+          # Verify resolved-repo-owner matches expected value
+          if [ "${{ steps.test-ci-vars.outputs.resolved-repo-owner }}" != "aaronsteers" ]; then
+            echo "ERROR: resolved-repo-owner should be aaronsteers"
+            echo "Actual: ${{ steps.test-ci-vars.outputs.resolved-repo-owner }}"
             exit 1
           fi
 
-          # Verify repo-owner matches expected value
-          if [ "${{ steps.test-ci-vars.outputs.repo-owner }}" != "aaronsteers" ]; then
-            echo "ERROR: repo-owner should be aaronsteers"
-            echo "Actual: ${{ steps.test-ci-vars.outputs.repo-owner }}"
+          # Verify resolved-repo-name matches expected value
+          if [ "${{ steps.test-ci-vars.outputs.resolved-repo-name }}" != "resolve-vars-action" ]; then
+            echo "ERROR: resolved-repo-name should be resolve-vars-action"
+            echo "Actual: ${{ steps.test-ci-vars.outputs.resolved-repo-name }}"
             exit 1
           fi
 
-          # Verify repo-name matches expected value
-          if [ "${{ steps.test-ci-vars.outputs.repo-name }}" != "resolve-vars-action" ]; then
-            echo "ERROR: repo-name should be resolve-vars-action"
-            echo "Actual: ${{ steps.test-ci-vars.outputs.repo-name }}"
-            exit 1
-          fi
-
-          # Verify repo-name-full matches expected value
-          if [ "${{ steps.test-ci-vars.outputs.repo-name-full }}" != "aaronsteers/resolve-vars-action" ]; then
-            echo "ERROR: repo-name-full should be aaronsteers/resolve-vars-action"
-            echo "Actual: ${{ steps.test-ci-vars.outputs.repo-name-full }}"
-            exit 1
-          fi
-
-          # Verify restricted-security-mode is false for non-fork PRs
-          if [ "${{ steps.test-ci-vars.outputs.restricted-security-mode }}" != "false" ]; then
-            echo "ERROR: restricted-security-mode should be false for non-fork PRs"
-            echo "Actual: ${{ steps.test-ci-vars.outputs.restricted-security-mode }}"
+          # Verify is-pr is false for non-PR events (this test runs on pull_request so should be true)
+          if [ "${{ steps.test-ci-vars.outputs.is-pr }}" != "true" ]; then
+            echo "ERROR: is-pr should be true for pull_request events"
+            echo "Actual: ${{ steps.test-ci-vars.outputs.is-pr }}"
             exit 1
           fi
 
           # Check that custom variables are still included
-          if [ "${{ fromJSON(steps.test-ci-vars.outputs.all).custom_var }}" != "test_value" ]; then
+          if [ "${{ fromJSON(steps.test-ci-vars.outputs.custom).custom_var }}" != "test_value" ]; then
             echo "ERROR: custom_var should still be included with standard CI vars"
             exit 1
           fi

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -33,67 +33,67 @@ jobs:
       - name: Print outputs
         run: |
           echo "=== DEBUG: Raw output ==="
-          echo "steps.test-vars.outputs.all: '${{ steps.test-vars.outputs.all }}'"
+          echo "steps.test-vars.outputs.custom: '${{ steps.test-vars.outputs.custom }}'"
           echo "=========================="
 
       - name: Verify outputs
         run: |
           # Check static variables
-          if [ "${{ fromJSON(steps.test-vars.outputs.all).username }}" != "testuser" ]; then
+          if [ "${{ fromJSON(steps.test-vars.outputs.custom).username }}" != "testuser" ]; then
             echo "ERROR: username output doesn't match expected value"
             exit 1
           fi
 
-          if [ "${{ fromJSON(steps.test-vars.outputs.all).environment }}" != "development" ]; then
+          if [ "${{ fromJSON(steps.test-vars.outputs.custom).environment }}" != "development" ]; then
             echo "ERROR: environment output doesn't match expected value"
             exit 1
           fi
 
           # Check jinja variables
-          if [ "${{ fromJSON(steps.test-vars.outputs.all).greeting }}" != "Hello, World!" ]; then
+          if [ "${{ fromJSON(steps.test-vars.outputs.custom).greeting }}" != "Hello, World!" ]; then
             echo "ERROR: greeting output doesn't match expected value"
             echo "Expected: Hello, World!"
-            echo "Actual: ${{ fromJSON(steps.test-vars.outputs.all).greeting }}"
+            echo "Actual: ${{ fromJSON(steps.test-vars.outputs.custom).greeting }}"
             exit 1
           fi
 
-          if [ "${{ fromJSON(steps.test-vars.outputs.all).is_prod }}" != "False" ]; then
+          if [ "${{ fromJSON(steps.test-vars.outputs.custom).is_prod }}" != "False" ]; then
             echo "ERROR: is_prod output doesn't match expected value"
             echo "Expected: False"
-            echo "Actual: ${{ fromJSON(steps.test-vars.outputs.all).is_prod }}"
+            echo "Actual: ${{ fromJSON(steps.test-vars.outputs.custom).is_prod }}"
             exit 1
           fi
 
-          if [ "${{ fromJSON(steps.test-vars.outputs.all).computed_name }}" != "testuser_development" ]; then
+          if [ "${{ fromJSON(steps.test-vars.outputs.custom).computed_name }}" != "testuser_development" ]; then
             echo "ERROR: computed_name output doesn't match expected value"
             echo "Expected: testuser_development"
-            echo "Actual: ${{ fromJSON(steps.test-vars.outputs.all).computed_name }}"
+            echo "Actual: ${{ fromJSON(steps.test-vars.outputs.custom).computed_name }}"
             exit 1
           fi
 
-          if [ "${{ fromJSON(steps.test-vars.outputs.all).port_number }}" != "443" ]; then
+          if [ "${{ fromJSON(steps.test-vars.outputs.custom).port_number }}" != "443" ]; then
             echo "ERROR: port_number output doesn't match expected value"
             echo "Expected: 443"
-            echo "Actual: ${{ fromJSON(steps.test-vars.outputs.all).port_number }}"
+            echo "Actual: ${{ fromJSON(steps.test-vars.outputs.custom).port_number }}"
             exit 1
           fi
 
-          if [ "${{ fromJSON(steps.test-vars.outputs.all).answer }}" != "42" ]; then
+          if [ "${{ fromJSON(steps.test-vars.outputs.custom).answer }}" != "42" ]; then
             echo "ERROR: answer output doesn't match expected value"
             echo "Expected: 42"
-            echo "Actual: ${{ fromJSON(steps.test-vars.outputs.all).answer }}"
+            echo "Actual: ${{ fromJSON(steps.test-vars.outputs.custom).answer }}"
             exit 1
           fi
 
           echo "✅ All tests passed!"
           echo "Static outputs:"
-          echo "  username: ${{ fromJSON(steps.test-vars.outputs.all).username }}"
-          echo "  environment: ${{ fromJSON(steps.test-vars.outputs.all).environment }}"
+          echo "  username: ${{ fromJSON(steps.test-vars.outputs.custom).username }}"
+          echo "  environment: ${{ fromJSON(steps.test-vars.outputs.custom).environment }}"
           echo "Jinja outputs:"
-          echo "  greeting: ${{ fromJSON(steps.test-vars.outputs.all).greeting }}"
-          echo "  is_prod: ${{ fromJSON(steps.test-vars.outputs.all).is_prod }}"
-          echo "  computed_name: ${{ fromJSON(steps.test-vars.outputs.all).computed_name }}"
-          echo "  port_number: ${{ fromJSON(steps.test-vars.outputs.all).port_number }}"
+          echo "  greeting: ${{ fromJSON(steps.test-vars.outputs.custom).greeting }}"
+          echo "  is_prod: ${{ fromJSON(steps.test-vars.outputs.custom).is_prod }}"
+          echo "  computed_name: ${{ fromJSON(steps.test-vars.outputs.custom).computed_name }}"
+          echo "  port_number: ${{ fromJSON(steps.test-vars.outputs.custom).port_number }}"
 
   test-standard-ci-vars:
     name: Test Standard CI Variables

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -204,7 +204,7 @@ jobs:
 
           echo "✅ Standard CI variables test passed!"
 
-      - name: Test standard CI vars disabled (backward compatibility)
+      - name: Test with standard CI vars disabled
         id: test-no-ci-vars
         uses: ./
         with:
@@ -212,7 +212,7 @@ jobs:
           static_inputs: |
             test_var=backward_compat
 
-      - name: Verify backward compatibility
+      - name: Verify standard CI vars disabled
         run: |
           # Ensure CI variables are NOT populated when disabled
           if [ -n "${{ steps.test-no-ci-vars.outputs.repo }}" ]; then
@@ -226,4 +226,4 @@ jobs:
             exit 1
           fi
 
-          echo "✅ Backward compatibility test passed!"
+          echo "✅ Standard CI vars disabled test passed!"

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -203,27 +203,3 @@ jobs:
           fi
 
           echo "✅ Standard CI variables test passed!"
-
-      - name: Test with standard CI vars disabled
-        id: test-no-ci-vars
-        uses: ./
-        with:
-          standard_ci_vars: false
-          static_inputs: |
-            test_var=backward_compat
-
-      - name: Verify standard CI vars disabled
-        run: |
-          # Ensure CI variables are NOT populated when disabled
-          if [ -n "${{ steps.test-no-ci-vars.outputs.repo }}" ]; then
-            echo "ERROR: repo should not be populated when standard_ci_vars is false"
-            exit 1
-          fi
-
-          # Ensure custom variables still work
-          if [ "${{ fromJSON(steps.test-no-ci-vars.outputs.all).test_var }}" != "backward_compat" ]; then
-            echo "ERROR: custom variables should still work when standard_ci_vars is false"
-            exit 1
-          fi
-
-          echo "✅ Standard CI vars disabled test passed!"

--- a/README.md
+++ b/README.md
@@ -145,12 +145,46 @@ The action automatically resolves common CI variables from GitHub context, elimi
     echo "All variables: ${{ steps.vars.outputs.custom }}"
 ```
 
+#### Workflow Dispatch Auto-Detection
+
+The action automatically detects and resolves common workflow_dispatch inputs:
+
+- **PR inputs**: `pr` or `pr-number` - Automatically resolves PR context and updates resolved variables to point to PR head
+- **Comment inputs**: `comment-id` - Resolves comment metadata for slash command workflows  
+- **Issue inputs**: `issue-id` or `issue-number` - Resolves issue context and constructs URLs
+
+```yaml
+# Example workflow_dispatch with auto-detected inputs
+on:
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: 'PR number to operate on'
+        required: false
+      comment-id:
+        description: 'Comment ID that triggered this'
+        required: false
+      issue-number:
+        description: 'Issue number'
+        required: false
+
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aaronsteers/resolve-vars-action@v1
+        id: vars
+      # All workflow_dispatch inputs are now available as resolved variables
+      - run: echo "Operating on PR: ${{ steps.vars.outputs.pr-number }}"
+```
+
 **Key Features:**
 - **Smart resolved context**: `resolved-*` variables always point to the effective working context (PR head for PRs, current branch otherwise)
 - **Explicit PR source/target**: Separate `pr-source-*` and `pr-target-*` variables for fine-grained PR workflows
 - **URL generation**: Automatic GitHub URLs for branches, commits, PRs, and comments
 - **Fork-aware**: Properly distinguishes between source and target repositories in fork scenarios
 - **Context detection**: `is-pr` boolean and other metadata for workflow logic
+- **Workflow dispatch auto-detection**: Automatically detects and resolves `pr`/`pr-number`, `comment-id`, and `issue-id`/`issue-number` inputs
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -85,39 +85,47 @@ The action automatically resolves common CI variables from GitHub context, elimi
 
 #### Standard CI Variables Reference
 
-| Variable | Description | Resolves From | Example Value |
-|----------|-------------|---------------|---------------|
-| **Repository & Git Context** |
-| `target-repo` | Target repository (base repo in owner/name format) | `github.repository` or `github.event.pull_request.base.repo.full_name` | `airbytehq/airbyte` |
-| `repo-owner` | Repository owner/organization | `github.repository_owner` | `airbytehq` |
-| `repo-name` | Repository name only | `github.event.repository.name` or extracted from repository | `airbyte` |
-| `repo-name-full` | Full repository name (owner/name) | Same as `target-repo` | `airbytehq/airbyte` |
-| `source-branch` | Source branch being merged (null for issues) | `github.head_ref` or `github.ref_name` | `feature/new-connector` |
-| `target-branch` | Target branch for merge (null for issues) | `github.base_ref` or default branch | `main` |
-| `source-repo` | Source repository (important for forks, null for issues) | `github.event.pull_request.head.repo.full_name` | `contributor/airbyte` |
-| `source-sha` | Source commit SHA (null for issues) | `github.event.pull_request.head.sha` | `abc123...` |
-| `target-sha` | Target commit SHA (null for issues) | `github.event.pull_request.base.sha` | `def456...` |
-| `restricted-security-mode` | Whether running in restricted security mode | `true` when from fork/dependabot and trigger is `pull_request` | `true` |
-| **Pull Request Variables** |
-| `pr-number` | Pull request number | `github.event.pull_request.number` or `github.event.issue.number` | `12345` |
-| `pr-title` | Pull request title | `github.event.pull_request.title` | `feat: Add new connector` |
-| `pr-author` | Pull request author username | `github.event.pull_request.user.login` | `contributor` |
-| `pr-draft` | Whether PR is draft | `github.event.pull_request.draft` | `true` |
-| `pr-from-fork` | Whether PR is from a fork | `github.event.pull_request.head.repo.fork` | `true` |
-| **Issue Variables** |
-| `issue-number` | Issue number (equals pr-number for PRs) | `github.event.issue.number` or `github.event.pull_request.number` | `12345` |
-| `issue-title` | Issue title | `github.event.issue.title` or `github.event.pull_request.title` | `Bug: Fix connector issue` |
-| `issue-author` | Issue author username | `github.event.issue.user.login` or `github.event.pull_request.user.login` | `reporter` |
-| `issue-type` | Type of issue context | Detected from event type | `pull_request` or `issue` |
-| **Comment Variables** |
-| `comment-id` | Comment ID that triggered workflow | `github.event.comment.id` | `987654321` |
-| `comment-author` | Comment author username | `github.event.comment.user.login` | `maintainer` |
-| `comment-body` | Comment body text | `github.event.comment.body` | `/test connector` |
-| **Workflow Context** |
-| `trigger-event` | Event that triggered workflow | `github.event_name` | `pull_request` |
-| `workflow-actor` | User who triggered the workflow | `github.actor` | `contributor` |
-| `run-id` | Workflow run ID | `github.run_id` | `123456789` |
-| `run-number` | Workflow run number | `github.run_number` | `42` |
+| Variable | Description | Example Value |
+|----------|-------------|---------------|
+| **Resolved Variables (always the effective context)** |
+| `resolved-git-ref` | Full Git ref (`refs/heads/...` or `refs/tags/...`) | `refs/heads/feature/new-connector` |
+| `resolved-git-branch` | Short branch name (e.g. `main`, `feature/foo`) | `feature/new-connector` |
+| `resolved-git-sha` | Commit SHA | `abc123...` |
+| `resolved-git-tag` | Tag name (if applicable) | `v1.0.0` |
+| `resolved-repo-name` | Repository name (e.g. `my-repo`) | `airbyte` |
+| `resolved-repo-owner` | Repository owner (user or org) | `airbytehq` |
+| `resolved-repo-full-name` | Owner + name (e.g. `myorg/my-repo`) | `airbytehq/airbyte` |
+| `resolved-git-branch-url` | URL to the branch in GitHub | `https://github.com/airbytehq/airbyte/tree/feature/new-connector` |
+| `resolved-git-commit-url` | URL to the commit in GitHub | `https://github.com/airbytehq/airbyte/commit/abc123...` |
+| **PR Source Variables (for PR workflows)** |
+| `pr-source-git-ref` | Git ref of the source (PR head) | `refs/heads/feature/new-connector` |
+| `pr-source-git-branch` | Branch name of the source | `feature/new-connector` |
+| `pr-source-git-sha` | SHA of the source commit | `abc123...` |
+| `pr-source-repo-name` | Source repo name | `airbyte` |
+| `pr-source-repo-owner` | Source repo owner | `contributor` |
+| `pr-source-repo-full-name` | Full source repo name (owner/name) | `contributor/airbyte` |
+| `pr-source-git-branch-url` | URL to the source branch | `https://github.com/contributor/airbyte/tree/feature/new-connector` |
+| `pr-source-git-commit-url` | URL to the source commit | `https://github.com/contributor/airbyte/commit/abc123...` |
+| `pr-source-is-fork` | Whether the source repo is a fork | `true` |
+| **PR Target Variables (for PR workflows)** |
+| `pr-target-git-ref` | Git ref of the target (PR base) | `refs/heads/main` |
+| `pr-target-git-branch` | Branch name of the target | `main` |
+| `pr-target-git-sha` | SHA of the target commit | `def456...` |
+| `pr-target-git-tag` | Tag name, if PR targets a tag | `` |
+| `pr-target-repo-name` | Target repo name | `airbyte` |
+| `pr-target-repo-owner` | Target repo owner | `airbytehq` |
+| `pr-target-repo-full-name` | Full target repo name (owner/name) | `airbytehq/airbyte` |
+| `pr-target-git-branch-url` | URL to the target branch | `https://github.com/airbytehq/airbyte/tree/main` |
+| `pr-target-git-commit-url` | URL to the target commit | `https://github.com/airbytehq/airbyte/commit/def456...` |
+| **Additional Resolved Metadata** |
+| `pr-number` | Pull request number (if applicable) | `12345` |
+| `pr-url` | URL to the pull request | `https://github.com/airbytehq/airbyte/pull/12345` |
+| `pr-title` | Title of the pull request | `feat: Add new connector` |
+| `comment-id` | ID of the triggering comment (if applicable) | `987654321` |
+| `comment-url` | URL to the triggering comment (if applicable) | `https://github.com/airbytehq/airbyte/issues/12345#issuecomment-987654321` |
+| `run-id` | GitHub Actions run ID | `123456789` |
+| `run-url` | URL to the GitHub Actions run | `https://github.com/airbytehq/airbyte/actions/runs/123456789` |
+| `is-pr` | Boolean: whether the current context is a PR | `true` |
 
 #### Usage Example
 
@@ -132,17 +140,17 @@ The action automatically resolves common CI variables from GitHub context, elimi
 - name: Use resolved variables
   run: |
     echo "PR Number: ${{ steps.vars.outputs.pr-number }}"
-    echo "Source Branch: ${{ steps.vars.outputs.source-branch }}"
-    echo "Repository: ${{ steps.vars.outputs.target-repo }}"
-    echo "All variables: ${{ steps.vars.outputs.all }}"
+    echo "Resolved Branch: ${{ steps.vars.outputs.resolved-git-branch }}"
+    echo "Repository: ${{ steps.vars.outputs.resolved-repo-full-name }}"
+    echo "All variables: ${{ steps.vars.outputs.custom }}"
 ```
 
 **Key Features:**
-- **Smart source-branch resolution**: Handles "run from main, operate on PR branch" pattern for slash commands
-- **Issue-aware**: Git refs are null for issue events since issues don't have branches
-- **Fork-friendly**: Properly distinguishes between source and target repositories
-- **Security-aware**: Detects restricted security mode for fork/dependabot PRs
-- **Trigger-agnostic**: Works with pull_request, workflow_dispatch, issue_comment, and more
+- **Smart resolved context**: `resolved-*` variables always point to the effective working context (PR head for PRs, current branch otherwise)
+- **Explicit PR source/target**: Separate `pr-source-*` and `pr-target-*` variables for fine-grained PR workflows
+- **URL generation**: Automatic GitHub URLs for branches, commits, PRs, and comments
+- **Fork-aware**: Properly distinguishes between source and target repositories in fork scenarios
+- **Context detection**: `is-pr` boolean and other metadata for workflow logic
 
 ---
 
@@ -200,11 +208,11 @@ jobs:
 
 | Output Name | Description                                                    |
 |-------------|----------------------------------------------------------------|
-| `all`       | JSON-encoded object with all resolved values                  |
+| `custom`    | JSON-encoded object with all resolved values                  |
 | `var1`      | Custom user-defined output variable 1                         |
 | `var2`      | Custom user-defined output variable 2                         |
 | `var3`      | Custom user-defined output variable 3                         |
-| `{variable-name}` | Individual outputs for each resolved variable (e.g., `pr-number`, `head-ref`) |
+| `{variable-name}` | Individual outputs for each resolved variable (e.g., `pr-number`, `resolved-git-branch`) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The action automatically resolves common CI variables from GitHub context, elimi
 | `resolved-git-tag` | Tag name (if applicable) | `v1.0.0` |
 | `resolved-repo-name` | Repository name (e.g. `my-repo`) | `airbyte` |
 | `resolved-repo-owner` | Repository owner (user or org) | `airbytehq` |
-| `resolved-repo-full-name` | Owner + name (e.g. `myorg/my-repo`) | `airbytehq/airbyte` |
+| `resolved-repo-name-full` | Owner + name (e.g. `myorg/my-repo`) | `airbytehq/airbyte` |
 | `resolved-git-branch-url` | URL to the branch in GitHub | `https://github.com/airbytehq/airbyte/tree/feature/new-connector` |
 | `resolved-git-commit-url` | URL to the commit in GitHub | `https://github.com/airbytehq/airbyte/commit/abc123...` |
 | **PR Source Variables (for PR workflows)** |
@@ -103,7 +103,7 @@ The action automatically resolves common CI variables from GitHub context, elimi
 | `pr-source-git-sha` | SHA of the source commit | `abc123...` |
 | `pr-source-repo-name` | Source repo name | `airbyte` |
 | `pr-source-repo-owner` | Source repo owner | `contributor` |
-| `pr-source-repo-full-name` | Full source repo name (owner/name) | `contributor/airbyte` |
+| `pr-source-repo-name-full` | Full source repo name (owner/name) | `contributor/airbyte` |
 | `pr-source-git-branch-url` | URL to the source branch | `https://github.com/contributor/airbyte/tree/feature/new-connector` |
 | `pr-source-git-commit-url` | URL to the source commit | `https://github.com/contributor/airbyte/commit/abc123...` |
 | `pr-source-is-fork` | Whether the source repo is a fork | `true` |
@@ -114,7 +114,7 @@ The action automatically resolves common CI variables from GitHub context, elimi
 | `pr-target-git-tag` | Tag name, if PR targets a tag | `` |
 | `pr-target-repo-name` | Target repo name | `airbyte` |
 | `pr-target-repo-owner` | Target repo owner | `airbytehq` |
-| `pr-target-repo-full-name` | Full target repo name (owner/name) | `airbytehq/airbyte` |
+| `pr-target-repo-name-full` | Full target repo name (owner/name) | `airbytehq/airbyte` |
 | `pr-target-git-branch-url` | URL to the target branch | `https://github.com/airbytehq/airbyte/tree/main` |
 | `pr-target-git-commit-url` | URL to the target commit | `https://github.com/airbytehq/airbyte/commit/def456...` |
 | **Additional Resolved Metadata** |
@@ -141,7 +141,7 @@ The action automatically resolves common CI variables from GitHub context, elimi
   run: |
     echo "PR Number: ${{ steps.vars.outputs.pr-number }}"
     echo "Resolved Branch: ${{ steps.vars.outputs.resolved-git-branch }}"
-    echo "Repository: ${{ steps.vars.outputs.resolved-repo-full-name }}"
+    echo "Repository: ${{ steps.vars.outputs.resolved-repo-name-full }}"
     echo "All variables: ${{ steps.vars.outputs.custom }}"
 ```
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ For help with Jinja2 expressions, check out these resources:
 
 ### Standard CI Vars
 
-When `standard_ci_vars` is enabled (default: `true`), the action automatically resolves common CI variables from GitHub context, eliminating the need for complex expressions like `${{ github.event.pull_request.head.repo.full_name || github.repository }}` throughout your workflows.
+The action automatically resolves common CI variables from GitHub context, eliminating the need for complex expressions like `${{ github.event.pull_request.head.repo.full_name || github.repository }}` throughout your workflows.
 
 #### Standard CI Variables Reference
 
@@ -126,7 +126,6 @@ When `standard_ci_vars` is enabled (default: `true`), the action automatically r
   id: vars
   uses: aaronsteers/resolve-vars-action@v1
   with:
-    standard_ci_vars: true
     static_inputs: |
       custom_var=my_value
 
@@ -192,7 +191,6 @@ jobs:
 |----------------|-----------------------------------------------------------------------------------------------------|----------|---------|
 | `static_inputs`| Variable assignments in key=value format (multiline string)                                        | ❌       |         |
 | `jinja_inputs` | Jinja2 expressions to evaluate (e.g. `user or default_user`)                                       | ❌       |         |
-| `standard_ci_vars` | Whether to automatically resolve standard CI variables from GitHub context                     | ❌       | `true` |
 | `log_outputs`  | Whether to log resolved values to the console and step summary                                      | ❌       | `false` |
 | `non_sensitive`| Alias for `log_outputs`                                                                            | ❌       | `false` |
 

--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ When `standard_ci_vars` is enabled (default: `true`), the action automatically r
 | Variable | Description | Resolves From | Example Value |
 |----------|-------------|---------------|---------------|
 | **Repository & Git Context** |
-| `target-repository` | Target repository (base repo in owner/name format) | `github.repository` or `github.event.pull_request.base.repo.full_name` | `airbytehq/airbyte` |
-| `repository-owner` | Repository owner/organization | `github.repository_owner` | `airbytehq` |
+| `target-repo` | Target repository (base repo in owner/name format) | `github.repository` or `github.event.pull_request.base.repo.full_name` | `airbytehq/airbyte` |
+| `repo-owner` | Repository owner/organization | `github.repository_owner` | `airbytehq` |
 | `repo-name` | Repository name only | `github.event.repository.name` or extracted from repository | `airbyte` |
-| `repo-name-full` | Full repository name (owner/name) | Same as `target-repository` | `airbytehq/airbyte` |
+| `repo-name-full` | Full repository name (owner/name) | Same as `target-repo` | `airbytehq/airbyte` |
 | `source-branch` | Source branch being merged (null for issues) | `github.head_ref` or `github.ref_name` | `feature/new-connector` |
 | `target-branch` | Target branch for merge (null for issues) | `github.base_ref` or default branch | `main` |
-| `source-repository` | Source repository (important for forks, null for issues) | `github.event.pull_request.head.repo.full_name` | `contributor/airbyte` |
+| `source-repo` | Source repository (important for forks, null for issues) | `github.event.pull_request.head.repo.full_name` | `contributor/airbyte` |
 | `source-sha` | Source commit SHA (null for issues) | `github.event.pull_request.head.sha` | `abc123...` |
 | `target-sha` | Target commit SHA (null for issues) | `github.event.pull_request.base.sha` | `def456...` |
 | `restricted-security-mode` | Whether running in restricted security mode | `true` when from fork/dependabot and trigger is `pull_request` | `true` |
@@ -134,7 +134,7 @@ When `standard_ci_vars` is enabled (default: `true`), the action automatically r
   run: |
     echo "PR Number: ${{ steps.vars.outputs.pr-number }}"
     echo "Source Branch: ${{ steps.vars.outputs.source-branch }}"
-    echo "Repository: ${{ steps.vars.outputs.target-repository }}"
+    echo "Repository: ${{ steps.vars.outputs.target-repo }}"
     echo "All variables: ${{ steps.vars.outputs.all }}"
 ```
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,69 @@ For help with Jinja2 expressions, check out these resources:
 
 ### Standard CI Vars
 
+Enable automatic resolution of common CI variables with `standard_ci_vars: true`. This eliminates the need for complex expressions like `${{ github.event.pull_request.head.repo.full_name || github.repository }}` throughout your workflows.
+
+#### Standard CI Variables Reference
+
+| Variable | Description | Resolves From | Example Value |
+|----------|-------------|---------------|---------------|
+| **Repository & Git Context** |
+| `repo` | Target repository (base repo in owner/name format) | `github.repository` or `github.event.pull_request.base.repo.full_name` | `airbytehq/airbyte` |
+| `repo-owner` | Target repository owner/organization | `github.repository_owner` | `airbytehq` |
+| `repo-name` | Target repository name only | Repository name from base repo | `airbyte` |
+| `head-ref` | Source branch/ref being merged (null for issues) | `github.head_ref` or `github.ref_name` | `feature/new-connector` |
+| `base-ref` | Target branch/ref for merge (null for issues) | `github.base_ref` or default branch | `main` |
+| `head-repo` | Source repository (important for forks, null for issues) | `github.event.pull_request.head.repo.full_name` | `contributor/airbyte` |
+| `base-repo` | Target repository (same as `repo`, null for issues) | `github.event.pull_request.base.repo.full_name` | `airbytehq/airbyte` |
+| `head-sha` | Head commit SHA (null for issues) | `github.event.pull_request.head.sha` | `abc123...` |
+| `base-sha` | Base commit SHA (null for issues) | `github.event.pull_request.base.sha` | `def456...` |
+| `gitref` | Smart ref resolution (null for issues) | PR head ref when `pr` input exists, otherwise `github.ref_name` | `feature/branch` |
+| **Pull Request Variables** |
+| `pr-number` | Pull request number | `github.event.pull_request.number` or `github.event.issue.number` | `12345` |
+| `pr-title` | Pull request title | `github.event.pull_request.title` | `feat: Add new connector` |
+| `pr-author` | Pull request author username | `github.event.pull_request.user.login` | `contributor` |
+| `pr-draft` | Whether PR is draft | `github.event.pull_request.draft` | `true` |
+| `is-pr-from-fork` | Whether PR is from a fork | `github.event.pull_request.head.repo.fork` | `true` |
+| **Issue Variables** |
+| `issue-number` | Issue number (equals pr-number for PRs) | `github.event.issue.number` or `github.event.pull_request.number` | `12345` |
+| `issue-title` | Issue title | `github.event.issue.title` or `github.event.pull_request.title` | `Bug: Fix connector issue` |
+| `issue-author` | Issue author username | `github.event.issue.user.login` or `github.event.pull_request.user.login` | `reporter` |
+| `issue-type` | Type of issue context | Detected from event type | `pull_request` or `issue` |
+| **Comment Variables** |
+| `comment-id` | Comment ID that triggered workflow | `github.event.comment.id` | `987654321` |
+| `comment-author` | Comment author username | `github.event.comment.user.login` | `maintainer` |
+| `comment-body` | Comment body text | `github.event.comment.body` | `/test connector` |
+| **Workflow Context** |
+| `trigger-type` | Event that triggered workflow | `github.event_name` | `pull_request` |
+| `actor` | User who triggered the workflow | `github.actor` | `contributor` |
+| `run-id` | Workflow run ID | `github.run_id` | `123456789` |
+| `run-number` | Workflow run number | `github.run_number` | `42` |
+
+#### Usage Example
+
+```yaml
+- name: Resolve CI variables
+  id: vars
+  uses: aaronsteers/resolve-vars-action@v1
+  with:
+    standard_ci_vars: true
+    static_inputs: |
+      custom_var=my_value
+
+- name: Use resolved variables
+  run: |
+    echo "PR Number: ${{ steps.vars.outputs.pr-number }}"
+    echo "Head Ref: ${{ steps.vars.outputs.head-ref }}"
+    echo "Repository: ${{ steps.vars.outputs.repo }}"
+    echo "All variables: ${{ steps.vars.outputs.all }}"
+```
+
+**Key Features:**
+- **Smart gitref resolution**: Handles "run from main, operate on PR branch" pattern for slash commands
+- **Issue-aware**: Git refs are null for issue events since issues don't have branches
+- **Fork-friendly**: Properly distinguishes between head and base repositories
+- **Trigger-agnostic**: Works with pull_request, workflow_dispatch, issue_comment, and more
+
 ---
 
 ## ✨ Features
@@ -126,9 +189,9 @@ jobs:
 
 | Name            | Description                                                                                         | Required | Default |
 |----------------|-----------------------------------------------------------------------------------------------------|----------|---------|
-| `static_inputs`| Comma-separated list of input variable names to coalesce                                           | ❌       |         |
-| `jinja_inputs` | Jinja2 expression to evaluate (e.g. `user or default_user`)                                         | ❌       |         |
-| `var1`-`var3`  | Optional named expressions. Will be exposed as `var1`-`var3` outputs.                  | ❌       |         |
+| `static_inputs`| Variable assignments in key=value format (multiline string)                                        | ❌       |         |
+| `jinja_inputs` | Jinja2 expressions to evaluate (e.g. `user or default_user`)                                       | ❌       |         |
+| `standard_ci_vars` | Whether to automatically resolve standard CI variables from GitHub context                     | ❌       | `false` |
 | `log_outputs`  | Whether to log resolved values to the console and step summary                                      | ❌       | `false` |
 | `non_sensitive`| Alias for `log_outputs`                                                                            | ❌       | `false` |
 
@@ -136,13 +199,13 @@ jobs:
 
 ## 📤 Outputs
 
-| Output Name | Description                                                    | Input Aliases              |
-|-------------|----------------------------------------------------------------|----------------------------|
-| `result`    | The resolved value from `static_inputs` or `jinja_inputs`     | `static_inputs`, `jinja_inputs` |
-| `var1`      | Custom user-defined output variable 1                         | `var1`                 |
-| `var2`      | Custom user-defined output variable 2                         | `var2`                 |
-| `var3`      | Custom user-defined output variable 3                         | `var3`                 |
-| `custom`    | JSON-encoded object with all resolved custom values           | N/A                        |
+| Output Name | Description                                                    |
+|-------------|----------------------------------------------------------------|
+| `all`       | JSON-encoded object with all resolved values                  |
+| `var1`      | Custom user-defined output variable 1                         |
+| `var2`      | Custom user-defined output variable 2                         |
+| `var3`      | Custom user-defined output variable 3                         |
+| `{variable-name}` | Individual outputs for each resolved variable (e.g., `pr-number`, `head-ref`) |
 
 ---
 

--- a/action.yml
+++ b/action.yml
@@ -157,8 +157,16 @@ runs:
           CI_VARS["base-repo"]="${{ github.repository }}"
           CI_VARS["head-sha"]="${{ github.sha }}"
           CI_VARS["base-sha"]=""  # Will be empty for workflow_dispatch
+        elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          # For workflow_dispatch without pr input, set both head-ref and base-ref to current branch
+          CI_VARS["head-ref"]="${{ github.ref_name }}"
+          CI_VARS["base-ref"]="${{ github.ref_name }}"
+          CI_VARS["head-repo"]="${{ github.repository }}"
+          CI_VARS["base-repo"]="${{ github.repository }}"
+          CI_VARS["head-sha"]="${{ github.sha }}"
+          CI_VARS["base-sha"]="${{ github.sha }}"
         else
-          # For issue events and workflow_dispatch without pr input, null out git refs
+          # For issue events, null out git refs since issues don't have branches
           CI_VARS["head-ref"]=""
           CI_VARS["base-ref"]=""
           CI_VARS["head-repo"]=""
@@ -171,12 +179,8 @@ runs:
         if [[ "${{ github.event_name }}" == "issues" || "${{ github.event_name }}" == "issue_comment" ]]; then
           # For issue events, null out gitref since issues don't have branches
           CI_VARS["gitref"]=""
-        elif [[ "${{ github.event_name }}" == "workflow_dispatch" && -z "${{ inputs.pr }}" ]]; then
-          # For workflow_dispatch without pr input, we can't tell if it's from issue or PR
-          # so null out gitref to be safe
-          CI_VARS["gitref"]=""
         elif [[ -n "${{ inputs.pr }}" ]]; then
-          # When pr input exists, we need to fetch the actual PR head ref
+          # When pr input exists, we need to fetch the actual PR head ref (fork's branch)
           # This handles slash commands that run from main but operate on PR branch
           echo "Resolving gitref for PR ${{ inputs.pr }}..."
           if command -v gh >/dev/null 2>&1; then
@@ -190,10 +194,10 @@ runs:
             CI_VARS["gitref"]="${{ github.head_ref || github.ref_name }}"
           fi
         elif [[ -n "${{ github.head_ref }}" ]]; then
-          # For direct PR events
+          # For direct PR events - use head ref (fork's branch)
           CI_VARS["gitref"]="${{ github.head_ref }}"
         else
-          # Fallback to current ref
+          # Fallback to current ref (for workflow_dispatch without pr input)
           CI_VARS["gitref"]="${{ github.ref_name }}"
         fi
         

--- a/action.yml
+++ b/action.yml
@@ -193,21 +193,12 @@ runs:
           temp_jinja_template="$GITHUB_WORKSPACE/.temp_template.j2"
           temp_jinja_output="$GITHUB_WORKSPACE/.temp_output.txt"
 
-          # Write current resolved variables to JSON file
-          echo "{" > "$temp_vars_file"
-          first=true
+          # Write current resolved variables to JSON file using jq
+          json_vars="{}"
           for var_name in "${!RESOLVED_VARS[@]}"; do
-            if [[ "$first" == "true" ]]; then
-              first=false
-            else
-              echo "," >> "$temp_vars_file"
-            fi
-            # Escape quotes in the value for JSON
-            escaped_value=$(printf '%s\n' "${RESOLVED_VARS[$var_name]}" | sed 's/"/\\"/g')
-            echo -n "  \"$var_name\": \"$escaped_value\"" >> "$temp_vars_file"
+            json_vars=$(echo "$json_vars" | jq --arg key "$var_name" --arg value "${RESOLVED_VARS[$var_name]}" '. + {($key): $value}')
           done
-          echo "" >> "$temp_vars_file"
-          echo "}" >> "$temp_vars_file"
+          echo "$json_vars" > "$temp_vars_file"
 
           # Save jinja_inputs and temp files to environment for next step
           # Set environment variables for the jinja renderer
@@ -225,9 +216,9 @@ runs:
           else
             json_payload+=","
           fi
-          # Escape quotes in the value
-          escaped_value=$(printf '%s\n' "${RESOLVED_VARS[$var_name]}" | sed 's/"/\\"/g')
-          json_payload+="\"$var_name\":\"$escaped_value\""
+          # Properly escape the value for JSON using jq
+          escaped_value=$(jq -R . <<< "${RESOLVED_VARS[$var_name]}")
+          json_payload+="\"$var_name\":${escaped_value}"
         done
         json_payload+="}"
 
@@ -436,22 +427,13 @@ runs:
         done
         
         # Store CI variables for merge step
-        ci_vars_json="{"
-        first=true
+        ci_vars_json="{}"
         for var_name in "${!CI_VARS[@]}"; do
           var_value="${CI_VARS[$var_name]}"
           if [[ -n "$var_value" && "$var_value" != "null" && "$var_value" != "" ]]; then
-            if [[ "$first" == "true" ]]; then
-              first=false
-            else
-              ci_vars_json+=","
-            fi
-            # Escape quotes in the value for JSON
-            escaped_value=$(printf '%s\n' "$var_value" | sed 's/"/\\"/g')
-            ci_vars_json+="\"$var_name\":\"$escaped_value\""
+            ci_vars_json=$(echo "$ci_vars_json" | jq --arg key "$var_name" --arg value "$var_value" '. + {($key): $value}')
           fi
         done
-        ci_vars_json+="}"
         echo "CI_VARS_JSON=$ci_vars_json" >> "$GITHUB_ENV"
 
     # Process Jinja inputs using external action if jinja_inputs provided
@@ -575,20 +557,11 @@ runs:
           rm -f "$TEMP_VARS_FILE" "$TEMP_JINJA_TEMPLATE" "$TEMP_JINJA_OUTPUT"
         fi
 
-        # Build final JSON object with all resolved variables
-        json_payload="{"
-        first=true
+        # Build final JSON object with all resolved variables using jq
+        json_payload="{}"
         for var_name in "${!RESOLVED_VARS[@]}"; do
-          if [[ "$first" == "true" ]]; then
-            first=false
-          else
-            json_payload+=","
-          fi
-          # Escape quotes in the value
-          escaped_value=$(printf '%s\n' "${RESOLVED_VARS[$var_name]}" | sed 's/"/\\"/g')
-          json_payload+="\"$var_name\":\"$escaped_value\""
+          json_payload=$(echo "$json_payload" | jq --arg key "$var_name" --arg value "${RESOLVED_VARS[$var_name]}" '. + {($key): $value}')
         done
-        json_payload+="}"
 
         # Output the JSON object as 'custom'
         echo "custom=$json_payload" >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -231,8 +231,8 @@ runs:
         CI_VARS["repo-owner"]="${{ github.repository_owner }}"
         repo_name="${{ github.event.repository.name }}"
         if [[ -z "$repo_name" ]]; then
-          repo_name="${{ github.repository }}"
-          repo_name="${repo_name##*/}"
+          repo_full="${{ github.repository }}"
+          repo_name="${repo_full##*/}"
         fi
         CI_VARS["repo-name"]="$repo_name"
         CI_VARS["repo-name-full"]="${{ github.event.pull_request.base.repo.full_name || github.repository }}"
@@ -271,13 +271,13 @@ runs:
         if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.pr }}" ]]; then
           # Validate PR input to prevent command injection
           pr_input="${{ inputs.pr }}"
-          if [[ "$pr_input" =~ ^[0-9]+$ ]]; then
+          if [[ "$pr_input" =~ ^[0-9]+$ ]] || [[ "$pr_input" =~ ^https://github\.com/[^/]+/[^/]+/pull/[0-9]+$ ]]; then
             echo "Resolving source-branch for PR $pr_input..."
             if command -v gh >/dev/null 2>&1; then
               source_branch=$(gh pr view "$pr_input" --json headRefName --jq '.headRefName' 2>/dev/null || echo "")
               if [[ -n "$source_branch" ]]; then
                 CI_VARS["source-branch"]="$source_branch"
-                # Also update source-repository to match the PR's head repo for consistency
+                # Also update source-repo to match the PR's head repo for consistency
                 source_repo=$(gh pr view "$pr_input" --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null || echo "")
                 if [[ -n "$source_repo" ]]; then
                   CI_VARS["source-repo"]="$source_repo"
@@ -289,7 +289,7 @@ runs:
               CI_VARS["source-branch"]="${{ github.ref_name }}"
             fi
           else
-            echo "Warning: Invalid PR input '$pr_input'. Must be a PR number." >&2
+            echo "Error: Invalid PR input '$pr_input'. Must be a PR number or valid PR URL." >&2
             CI_VARS["source-branch"]="${{ github.ref_name }}"
           fi
         fi

--- a/action.yml
+++ b/action.yml
@@ -335,34 +335,63 @@ runs:
           CI_VARS["pr-target-git-tag"]=""
         fi
         
-        # Smart resolution for workflow_dispatch with PR input
-        if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.pr }}" ]]; then
-          # Validate PR input to prevent command injection
-          pr_input="${{ inputs.pr }}"
-          if [[ "$pr_input" =~ ^[0-9]+$ ]] || [[ "$pr_input" =~ ^https://github\.com/[^/]+/[^/]+/pull/[0-9]+$ ]]; then
-            echo "Resolving PR data for PR $pr_input..."
-            if [[ "${{ steps.check-gh-cli.outputs.gh-available }}" == "true" ]]; then
-              # Fetch PR data and update resolved variables to point to PR head
-              pr_data=$(gh pr view "$pr_input" --json headRefName,headRepository,headRepositoryOwner 2>/dev/null || echo "")
-              if [[ -n "$pr_data" ]]; then
-                source_branch=$(echo "$pr_data" | jq -r '.headRefName // empty')
-                source_repo=$(echo "$pr_data" | jq -r '.headRepository.nameWithOwner // empty')
-                source_owner=$(echo "$pr_data" | jq -r '.headRepositoryOwner.login // empty')
-                source_repo_name=$(echo "$pr_data" | jq -r '.headRepository.name // empty')
-                
-                if [[ -n "$source_branch" ]]; then
-                  # Update resolved variables to point to PR head
-                  CI_VARS["resolved-git-ref"]="refs/heads/$source_branch"
-                  CI_VARS["resolved-git-branch"]="$source_branch"
-                  CI_VARS["resolved-repo-name-full"]="$source_repo"
-                  CI_VARS["resolved-repo-owner"]="$source_owner"
-                  CI_VARS["resolved-repo-name"]="$source_repo_name"
-                  CI_VARS["resolved-git-branch-url"]="https://github.com/$source_repo/tree/$source_branch"
+        # Auto-detect workflow_dispatch inputs and update variables accordingly
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          echo "Detecting workflow_dispatch inputs..."
+          
+          # Auto-detect PR input (pr or pr-number)
+          pr_input="${{ github.event.inputs.pr || github.event.inputs.pr-number }}"
+          if [[ -n "$pr_input" ]]; then
+            # Validate PR input to prevent command injection
+            if [[ "$pr_input" =~ ^[0-9]+$ ]] || [[ "$pr_input" =~ ^https://github\.com/[^/]+/[^/]+/pull/[0-9]+$ ]]; then
+              echo "Auto-detected PR input: $pr_input"
+              CI_VARS["pr-number"]="$pr_input"
+              
+              if [[ "${{ steps.check-gh-cli.outputs.gh-available }}" == "true" ]]; then
+                # Fetch PR data and update resolved variables to point to PR head
+                pr_data=$(gh pr view "$pr_input" --json headRefName,headRepository,headRepositoryOwner,number,title 2>/dev/null || echo "")
+                if [[ -n "$pr_data" ]]; then
+                  source_branch=$(echo "$pr_data" | jq -r '.headRefName // empty')
+                  source_repo=$(echo "$pr_data" | jq -r '.headRepository.nameWithOwner // empty')
+                  source_owner=$(echo "$pr_data" | jq -r '.headRepositoryOwner.login // empty')
+                  source_repo_name=$(echo "$pr_data" | jq -r '.headRepository.name // empty')
+                  pr_title=$(echo "$pr_data" | jq -r '.title // empty')
+                  
+                  if [[ -n "$source_branch" ]]; then
+                    # Update resolved variables to point to PR head
+                    CI_VARS["resolved-git-ref"]="refs/heads/$source_branch"
+                    CI_VARS["resolved-git-branch"]="$source_branch"
+                    CI_VARS["resolved-repo-name-full"]="$source_repo"
+                    CI_VARS["resolved-repo-owner"]="$source_owner"
+                    CI_VARS["resolved-repo-name"]="$source_repo_name"
+                    CI_VARS["resolved-git-branch-url"]="https://github.com/$source_repo/tree/$source_branch"
+                    CI_VARS["pr-title"]="$pr_title"
+                    CI_VARS["pr-url"]="https://github.com/${{ github.repository }}/pull/$pr_input"
+                    CI_VARS["is-pr"]="true"
+                  fi
                 fi
               fi
+            else
+              echo "Error: Invalid PR input '$pr_input'. Must be a PR number or valid PR URL." >&2
             fi
-          else
-            echo "Error: Invalid PR input '$pr_input'. Must be a PR number or valid PR URL." >&2
+          fi
+          
+          # Auto-detect comment-id input
+          comment_id_input="${{ github.event.inputs.comment-id }}"
+          if [[ -n "$comment_id_input" ]]; then
+            echo "Auto-detected comment-id input: $comment_id_input"
+            CI_VARS["comment-id"]="$comment_id_input"
+          fi
+          
+          # Auto-detect issue input (issue-id or issue-number)
+          issue_input="${{ github.event.inputs.issue-id || github.event.inputs.issue-number }}"
+          if [[ -n "$issue_input" ]]; then
+            echo "Auto-detected issue input: $issue_input"
+            CI_VARS["issue-number"]="$issue_input"
+            # If we have both issue and comment, construct comment URL
+            if [[ -n "$comment_id_input" && -n "$issue_input" ]]; then
+              CI_VARS["comment-url"]="https://github.com/${{ github.repository }}/issues/$issue_input#issuecomment-$comment_id_input"
+            fi
           fi
         fi
         

--- a/action.yml
+++ b/action.yml
@@ -570,16 +570,16 @@ runs:
         # Output the JSON object as 'custom'
         echo "custom=$json_payload_compact" >> "$GITHUB_OUTPUT"
 
-        # Logging with emoji grouping for better scanability
+        # Logging with GitHub Actions grouping for better scanability
         SHOULD_LOG="${{ inputs.log_outputs == 'true' || inputs.non_sensitive == 'true' }}"
         if [[ "$SHOULD_LOG" == "true" ]]; then
-          echo "🔧 ===== Variable Resolution Results ====="
+          echo "::group::🔧 Variable Resolution Results"
           echo "✅ Resolved variables:"
           for var_name in "${!RESOLVED_VARS[@]}"; do
             echo "  📝 $var_name: ${RESOLVED_VARS[$var_name]}"
           done
           echo "  📦 custom (JSON): $json_payload_compact"
-          echo "🔧 ===== End Variable Resolution ====="
+          echo "::endgroup::"
 
           {
             echo "### 🔍 Variable Resolution Summary"

--- a/action.yml
+++ b/action.yml
@@ -236,8 +236,6 @@ runs:
         fi
         CI_VARS["repo-name"]="$repo_name"
         CI_VARS["repo-name-full"]="${{ github.event.pull_request.base.repo.full_name || github.repository }}"
-        CI_VARS["repo-name-full"]="${{ github.event.pull_request.base.repo.full_name || github.repository }}"
-        CI_VARS["repo-name-full"]="${{ github.event.pull_request.base.repo.full_name || github.repository }}"
         
         # Git refs - only populate for PR events, null for issue events and workflow_dispatch without pr input
         if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "pull_request_target" ]]; then

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,13 @@ inputs:
       Alias for log_outputs (true = show evaluated output)
     default: 'false'
     required: false
+  standard_ci_vars:
+    description: >
+      Whether to automatically resolve standard CI variables from GitHub context.
+      When enabled, variables like pr-number, head-ref, base-ref, etc. are automatically
+      populated based on the trigger type.
+    default: 'false'
+    required: false
 outputs:
   all:
     value: ${{ steps.merge-results.outputs.all_vars }}
@@ -122,6 +129,126 @@ runs:
         # Save initial JSON for potential jinja processing
         echo "INITIAL_JSON=$json_payload" >> "$GITHUB_ENV"
 
+    # Process standard CI variables if enabled
+    - id: resolve-standard-ci-vars
+      if: ${{ inputs.standard_ci_vars == 'true' }}
+      shell: bash
+      run: |
+        declare -A CI_VARS
+        
+        # Repository & Git Context
+        CI_VARS["repo"]="${{ github.event.pull_request.base.repo.full_name || github.repository }}"
+        CI_VARS["repo-owner"]="${{ github.repository_owner }}"
+        CI_VARS["repo-name"]="${{ github.event.repository.name || github.repository }}"
+        
+        # Git refs - only populate for PR events, null for issue events and workflow_dispatch without pr input
+        if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "pull_request_target" ]]; then
+          CI_VARS["head-ref"]="${{ github.head_ref || github.ref_name }}"
+          CI_VARS["base-ref"]="${{ github.base_ref || github.event.repository.default_branch || 'main' }}"
+          CI_VARS["head-repo"]="${{ github.event.pull_request.head.repo.full_name || github.repository }}"
+          CI_VARS["base-repo"]="${{ github.event.pull_request.base.repo.full_name || github.repository }}"
+          CI_VARS["head-sha"]="${{ github.event.pull_request.head.sha || github.sha }}"
+          CI_VARS["base-sha"]="${{ github.event.pull_request.base.sha }}"
+        elif [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.pr }}" ]]; then
+          # For workflow_dispatch with pr input, we can populate some refs but need to fetch PR data
+          CI_VARS["head-ref"]="${{ github.ref_name }}"  # This will be updated by gitref resolution
+          CI_VARS["base-ref"]="${{ github.event.repository.default_branch || 'main' }}"
+          CI_VARS["head-repo"]="${{ github.repository }}"
+          CI_VARS["base-repo"]="${{ github.repository }}"
+          CI_VARS["head-sha"]="${{ github.sha }}"
+          CI_VARS["base-sha"]=""  # Will be empty for workflow_dispatch
+        else
+          # For issue events and workflow_dispatch without pr input, null out git refs
+          CI_VARS["head-ref"]=""
+          CI_VARS["base-ref"]=""
+          CI_VARS["head-repo"]=""
+          CI_VARS["base-repo"]=""
+          CI_VARS["head-sha"]=""
+          CI_VARS["base-sha"]=""
+        fi
+        
+        # Smart gitref resolution - handles "run from main, operate on PR branch" pattern
+        if [[ "${{ github.event_name }}" == "issues" || "${{ github.event_name }}" == "issue_comment" ]]; then
+          # For issue events, null out gitref since issues don't have branches
+          CI_VARS["gitref"]=""
+        elif [[ "${{ github.event_name }}" == "workflow_dispatch" && -z "${{ inputs.pr }}" ]]; then
+          # For workflow_dispatch without pr input, we can't tell if it's from issue or PR
+          # so null out gitref to be safe
+          CI_VARS["gitref"]=""
+        elif [[ -n "${{ inputs.pr }}" ]]; then
+          # When pr input exists, we need to fetch the actual PR head ref
+          # This handles slash commands that run from main but operate on PR branch
+          echo "Resolving gitref for PR ${{ inputs.pr }}..."
+          if command -v gh >/dev/null 2>&1; then
+            gitref=$(gh pr view "${{ inputs.pr }}" --json headRefName --jq '.headRefName' 2>/dev/null || echo "")
+            if [[ -n "$gitref" ]]; then
+              CI_VARS["gitref"]="$gitref"
+            else
+              CI_VARS["gitref"]="${{ github.head_ref || github.ref_name }}"
+            fi
+          else
+            CI_VARS["gitref"]="${{ github.head_ref || github.ref_name }}"
+          fi
+        elif [[ -n "${{ github.head_ref }}" ]]; then
+          # For direct PR events
+          CI_VARS["gitref"]="${{ github.head_ref }}"
+        else
+          # Fallback to current ref
+          CI_VARS["gitref"]="${{ github.ref_name }}"
+        fi
+        
+        # Pull Request Variables
+        CI_VARS["pr-number"]="${{ github.event.pull_request.number || github.event.issue.number }}"
+        CI_VARS["pr-title"]="${{ github.event.pull_request.title }}"
+        CI_VARS["pr-author"]="${{ github.event.pull_request.user.login }}"
+        CI_VARS["pr-draft"]="${{ github.event.pull_request.draft }}"
+        CI_VARS["is-pr-from-fork"]="${{ github.event.pull_request.head.repo.fork }}"
+        
+        # Issue Variables  
+        CI_VARS["issue-number"]="${{ github.event.issue.number || github.event.pull_request.number }}"
+        CI_VARS["issue-title"]="${{ github.event.issue.title || github.event.pull_request.title }}"
+        CI_VARS["issue-author"]="${{ github.event.issue.user.login || github.event.pull_request.user.login }}"
+        CI_VARS["issue-type"]="${{ github.event.pull_request && 'pull_request' || 'issue' }}"
+        
+        # Comment Variables
+        CI_VARS["comment-id"]="${{ github.event.comment.id }}"
+        CI_VARS["comment-author"]="${{ github.event.comment.user.login }}"
+        CI_VARS["comment-body"]="${{ github.event.comment.body }}"
+        
+        # Workflow Context
+        CI_VARS["trigger-type"]="${{ github.event_name }}"
+        CI_VARS["actor"]="${{ github.actor }}"
+        CI_VARS["run-id"]="${{ github.run_id }}"
+        CI_VARS["run-number"]="${{ github.run_number }}"
+        
+        # Output each CI variable that has a value
+        for var_name in "${!CI_VARS[@]}"; do
+          var_value="${CI_VARS[$var_name]}"
+          if [[ -n "$var_value" && "$var_value" != "null" && "$var_value" != "" ]]; then
+            echo "$var_name=$var_value" >> "$GITHUB_OUTPUT"
+            echo "Resolved CI variable: $var_name = $var_value"
+          fi
+        done
+        
+        # Store CI variables for merge step
+        ci_vars_json="{"
+        first=true
+        for var_name in "${!CI_VARS[@]}"; do
+          var_value="${CI_VARS[$var_name]}"
+          if [[ -n "$var_value" && "$var_value" != "null" && "$var_value" != "" ]]; then
+            if [[ "$first" == "true" ]]; then
+              first=false
+            else
+              ci_vars_json+=","
+            fi
+            # Escape quotes in the value for JSON
+            escaped_value=$(printf '%s\n' "$var_value" | sed 's/"/\\"/g')
+            ci_vars_json+="\"$var_name\":\"$escaped_value\""
+          fi
+        done
+        ci_vars_json+="}"
+        echo "CI_VARS_JSON=$ci_vars_json" >> "$GITHUB_ENV"
+
     # Process Jinja inputs using external action if jinja_inputs provided
     - id: process-jinja
       if: ${{ inputs.jinja_inputs != '' }}
@@ -204,6 +331,18 @@ runs:
               RESOLVED_VARS["$var_name"]="$var_value"
             fi
           done <<< "${{ inputs.static_inputs }}"
+        fi
+
+        # Add CI variables to RESOLVED_VARS if standard_ci_vars is enabled
+        if [[ "${{ inputs.standard_ci_vars }}" == "true" && -n "$CI_VARS_JSON" ]]; then
+          echo "Adding standard CI variables..."
+          # Parse CI_VARS_JSON and add to RESOLVED_VARS
+          while IFS="=" read -r key value; do
+            if [[ -n "$key" && -n "$value" ]]; then
+              RESOLVED_VARS["$key"]="$value"
+              echo "Added CI variable: $key = $value"
+            fi
+          done < <(echo "$CI_VARS_JSON" | jq -r 'to_entries[] | "\(.key)=\(.value)"' 2>/dev/null || echo "")
         fi
 
         # Process jinja results if they exist

--- a/action.yml
+++ b/action.yml
@@ -245,14 +245,14 @@ runs:
         # Resolved Variables (always the effective context)
         # For PRs: resolved = source (head), for other contexts: resolved = current
         if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "pull_request_target" ]]; then
-          CI_VARS["resolved-git-ref"]="refs/heads/${{ github.head_ref || github.ref_name }}"
-          CI_VARS["resolved-git-branch"]="${{ github.head_ref || github.ref_name }}"
-          CI_VARS["resolved-git-sha"]="${{ github.event.pull_request.head.sha || github.sha }}"
-          CI_VARS["resolved-repo-name-full"]="${{ github.event.pull_request.head.repo.full_name || github.repository }}"
-          CI_VARS["resolved-repo-owner"]="${{ github.event.pull_request.head.repo.owner.login || github.repository_owner }}"
+          CI_VARS["resolved-git-ref"]="refs/heads/${{ github.head_ref != '' && github.head_ref || github.ref_name }}"
+          CI_VARS["resolved-git-branch"]="${{ github.head_ref != '' && github.head_ref || github.ref_name }}"
+          CI_VARS["resolved-git-sha"]="${{ github.event.pull_request.head.sha != '' && github.event.pull_request.head.sha || github.sha }}"
+          CI_VARS["resolved-repo-name-full"]="${{ github.event.pull_request.head.repo.full_name != '' && github.event.pull_request.head.repo.full_name || github.repository }}"
+          CI_VARS["resolved-repo-owner"]="${{ github.event.pull_request.head.repo.owner.login != '' && github.event.pull_request.head.repo.owner.login || github.repository_owner }}"
           resolved_repo_name="${{ github.event.pull_request.head.repo.name }}"
           if [[ -z "$resolved_repo_name" ]]; then
-            resolved_repo_full="${{ github.event.pull_request.head.repo.full_name || github.repository }}"
+            resolved_repo_full="${{ github.event.pull_request.head.repo.full_name != '' && github.event.pull_request.head.repo.full_name || github.repository }}"
             resolved_repo_name="${resolved_repo_full##*/}"
           fi
           CI_VARS["resolved-repo-name"]="$resolved_repo_name"
@@ -334,13 +334,13 @@ runs:
           pr_input="${{ github.event.inputs.pr || github.event.inputs.pr-number }}"
           if [[ -n "$pr_input" ]]; then
             # Validate PR input to prevent command injection
-            if [[ "$pr_input" =~ ^[0-9]+$ ]] || [[ "$pr_input" =~ ^https://github\.com/[^/]+/[^/]+/pull/[0-9]+$ ]]; then
+            if [[ "$pr_input" =~ ^[0-9]+$ ]] || [[ "$pr_input" =~ ^https://github\.com/[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+/pull/[0-9]+$ ]]; then
               echo "Auto-detected PR input: $pr_input"
               CI_VARS["pr-number"]="$pr_input"
               
               if [[ "${{ steps.check-gh-cli.outputs.gh-available }}" == "true" ]]; then
                 # Fetch PR data and update resolved variables to point to PR head
-                pr_data=$(gh pr view "$pr_input" --json headRefName,headRepository,headRepositoryOwner,number,title 2>/dev/null || echo "")
+                pr_data=$(gh pr view --json headRefName,headRepository,headRepositoryOwner,number,title -- "$pr_input" 2>/dev/null || echo "")
                 if [[ -n "$pr_data" ]]; then
                   source_branch=$(echo "$pr_data" | jq -r '.headRefName // empty')
                   source_repo=$(echo "$pr_data" | jq -r '.headRepository.nameWithOwner // empty')
@@ -375,7 +375,7 @@ runs:
           fi
           
           # Auto-detect issue input (issue-id or issue-number)
-          issue_input="${{ github.event.inputs.issue-id || github.event.inputs.issue-number }}"
+          issue_input="${{ github.event.inputs.issue-id != '' && github.event.inputs.issue-id || github.event.inputs.issue-number }}"
           if [[ -n "$issue_input" ]]; then
             echo "Auto-detected issue input: $issue_input"
             CI_VARS["issue-number"]="$issue_input"
@@ -387,7 +387,7 @@ runs:
         fi
         
         # PR Variables
-        CI_VARS["pr-number"]="${{ github.event.pull_request.number || github.event.issue.number }}"
+        CI_VARS["pr-number"]="${{ github.event.pull_request.number != '' && github.event.pull_request.number || github.event.issue.number }}"
         CI_VARS["pr-title"]="${{ github.event.pull_request.title }}"
         if [[ -n "${{ github.event.pull_request.number }}" ]]; then
           CI_VARS["pr-url"]="https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
@@ -398,7 +398,7 @@ runs:
         # Comment Variables
         CI_VARS["comment-id"]="${{ github.event.comment.id }}"
         if [[ -n "${{ github.event.comment.id }}" ]]; then
-          CI_VARS["comment-url"]="https://github.com/${{ github.repository }}/issues/${{ github.event.issue.number || github.event.pull_request.number }}#issuecomment-${{ github.event.comment.id }}"
+          CI_VARS["comment-url"]="https://github.com/${{ github.repository }}/issues/${{ github.event.issue.number != '' && github.event.issue.number || github.event.pull_request.number }}#issuecomment-${{ github.event.comment.id }}"
         else
           CI_VARS["comment-url"]=""
         fi

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
     required: false
 outputs:
   custom:
-    value: ${{ steps.merge-results.outputs.all_vars }}
+    value: ${{ steps.merge-results.outputs.custom }}
     description: 'JSON-encoded object with all resolved values'
   # Resolved Variables (always the effective context)
   resolved-git-ref:
@@ -46,8 +46,8 @@ outputs:
   resolved-repo-owner:
     value: ${{ steps.merge-results.outputs.resolved-repo-owner }}
     description: 'Repository owner (user or org)'
-  resolved-repo-full-name:
-    value: ${{ steps.merge-results.outputs.resolved-repo-full-name }}
+  resolved-repo-name-full:
+    value: ${{ steps.merge-results.outputs.resolved-repo-name-full }}
     description: 'Owner + name (e.g. myorg/my-repo)'
   resolved-git-branch-url:
     value: ${{ steps.merge-results.outputs.resolved-git-branch-url }}
@@ -71,8 +71,8 @@ outputs:
   pr-source-repo-owner:
     value: ${{ steps.merge-results.outputs.pr-source-repo-owner }}
     description: 'Source repo owner'
-  pr-source-repo-full-name:
-    value: ${{ steps.merge-results.outputs.pr-source-repo-full-name }}
+  pr-source-repo-name-full:
+    value: ${{ steps.merge-results.outputs.pr-source-repo-name-full }}
     description: 'Full source repo name (owner/name)'
   pr-source-git-branch-url:
     value: ${{ steps.merge-results.outputs.pr-source-git-branch-url }}
@@ -102,8 +102,8 @@ outputs:
   pr-target-repo-owner:
     value: ${{ steps.merge-results.outputs.pr-target-repo-owner }}
     description: 'Target repo owner'
-  pr-target-repo-full-name:
-    value: ${{ steps.merge-results.outputs.pr-target-repo-full-name }}
+  pr-target-repo-name-full:
+    value: ${{ steps.merge-results.outputs.pr-target-repo-name-full }}
     description: 'Full target repo name (owner/name)'
   pr-target-git-branch-url:
     value: ${{ steps.merge-results.outputs.pr-target-git-branch-url }}
@@ -257,7 +257,7 @@ runs:
           CI_VARS["resolved-git-ref"]="refs/heads/${{ github.head_ref || github.ref_name }}"
           CI_VARS["resolved-git-branch"]="${{ github.head_ref || github.ref_name }}"
           CI_VARS["resolved-git-sha"]="${{ github.event.pull_request.head.sha || github.sha }}"
-          CI_VARS["resolved-repo-full-name"]="${{ github.event.pull_request.head.repo.full_name || github.repository }}"
+          CI_VARS["resolved-repo-name-full"]="${{ github.event.pull_request.head.repo.full_name || github.repository }}"
           CI_VARS["resolved-repo-owner"]="${{ github.event.pull_request.head.repo.owner.login || github.repository_owner }}"
           resolved_repo_name="${{ github.event.pull_request.head.repo.name }}"
           if [[ -z "$resolved_repo_name" ]]; then
@@ -269,7 +269,7 @@ runs:
           CI_VARS["resolved-git-ref"]="${{ github.ref }}"
           CI_VARS["resolved-git-branch"]="${{ github.ref_name }}"
           CI_VARS["resolved-git-sha"]="${{ github.sha }}"
-          CI_VARS["resolved-repo-full-name"]="${{ github.repository }}"
+          CI_VARS["resolved-repo-name-full"]="${{ github.repository }}"
           CI_VARS["resolved-repo-owner"]="${{ github.repository_owner }}"
           repo_name="${{ github.event.repository.name }}"
           if [[ -z "$repo_name" ]]; then
@@ -280,8 +280,8 @@ runs:
         fi
         
         # Generate URLs for resolved context
-        CI_VARS["resolved-git-branch-url"]="https://github.com/${CI_VARS["resolved-repo-full-name"]}/tree/${CI_VARS["resolved-git-branch"]}"
-        CI_VARS["resolved-git-commit-url"]="https://github.com/${CI_VARS["resolved-repo-full-name"]}/commit/${CI_VARS["resolved-git-sha"]}"
+        CI_VARS["resolved-git-branch-url"]="https://github.com/${CI_VARS["resolved-repo-name-full"]}/tree/${CI_VARS["resolved-git-branch"]}"
+        CI_VARS["resolved-git-commit-url"]="https://github.com/${CI_VARS["resolved-repo-name-full"]}/commit/${CI_VARS["resolved-git-sha"]}"
         
         # Git tag (if applicable)
         if [[ "${{ github.ref }}" =~ ^refs/tags/ ]]; then
@@ -296,29 +296,29 @@ runs:
           CI_VARS["pr-source-git-ref"]="refs/heads/${{ github.head_ref }}"
           CI_VARS["pr-source-git-branch"]="${{ github.head_ref }}"
           CI_VARS["pr-source-git-sha"]="${{ github.event.pull_request.head.sha }}"
-          CI_VARS["pr-source-repo-full-name"]="${{ github.event.pull_request.head.repo.full_name }}"
+          CI_VARS["pr-source-repo-name-full"]="${{ github.event.pull_request.head.repo.full_name }}"
           CI_VARS["pr-source-repo-owner"]="${{ github.event.pull_request.head.repo.owner.login }}"
           CI_VARS["pr-source-repo-name"]="${{ github.event.pull_request.head.repo.name }}"
           CI_VARS["pr-source-is-fork"]="${{ github.event.pull_request.head.repo.fork }}"
-          CI_VARS["pr-source-git-branch-url"]="https://github.com/${CI_VARS["pr-source-repo-full-name"]}/tree/${CI_VARS["pr-source-git-branch"]}"
-          CI_VARS["pr-source-git-commit-url"]="https://github.com/${CI_VARS["pr-source-repo-full-name"]}/commit/${CI_VARS["pr-source-git-sha"]}"
+          CI_VARS["pr-source-git-branch-url"]="https://github.com/${CI_VARS["pr-source-repo-name-full"]}/tree/${CI_VARS["pr-source-git-branch"]}"
+          CI_VARS["pr-source-git-commit-url"]="https://github.com/${CI_VARS["pr-source-repo-name-full"]}/commit/${CI_VARS["pr-source-git-sha"]}"
           
           # PR Target (base)
           CI_VARS["pr-target-git-ref"]="refs/heads/${{ github.base_ref }}"
           CI_VARS["pr-target-git-branch"]="${{ github.base_ref }}"
           CI_VARS["pr-target-git-sha"]="${{ github.event.pull_request.base.sha }}"
-          CI_VARS["pr-target-repo-full-name"]="${{ github.event.pull_request.base.repo.full_name }}"
+          CI_VARS["pr-target-repo-name-full"]="${{ github.event.pull_request.base.repo.full_name }}"
           CI_VARS["pr-target-repo-owner"]="${{ github.event.pull_request.base.repo.owner.login }}"
           CI_VARS["pr-target-repo-name"]="${{ github.event.pull_request.base.repo.name }}"
-          CI_VARS["pr-target-git-branch-url"]="https://github.com/${CI_VARS["pr-target-repo-full-name"]}/tree/${CI_VARS["pr-target-git-branch"]}"
-          CI_VARS["pr-target-git-commit-url"]="https://github.com/${CI_VARS["pr-target-repo-full-name"]}/commit/${CI_VARS["pr-target-git-sha"]}"
+          CI_VARS["pr-target-git-branch-url"]="https://github.com/${CI_VARS["pr-target-repo-name-full"]}/tree/${CI_VARS["pr-target-git-branch"]}"
+          CI_VARS["pr-target-git-commit-url"]="https://github.com/${CI_VARS["pr-target-repo-name-full"]}/commit/${CI_VARS["pr-target-git-sha"]}"
           CI_VARS["pr-target-git-tag"]=""
         else
           # For non-PR events, null out PR-specific variables
           CI_VARS["pr-source-git-ref"]=""
           CI_VARS["pr-source-git-branch"]=""
           CI_VARS["pr-source-git-sha"]=""
-          CI_VARS["pr-source-repo-full-name"]=""
+          CI_VARS["pr-source-repo-name-full"]=""
           CI_VARS["pr-source-repo-owner"]=""
           CI_VARS["pr-source-repo-name"]=""
           CI_VARS["pr-source-is-fork"]=""
@@ -327,7 +327,7 @@ runs:
           CI_VARS["pr-target-git-ref"]=""
           CI_VARS["pr-target-git-branch"]=""
           CI_VARS["pr-target-git-sha"]=""
-          CI_VARS["pr-target-repo-full-name"]=""
+          CI_VARS["pr-target-repo-name-full"]=""
           CI_VARS["pr-target-repo-owner"]=""
           CI_VARS["pr-target-repo-name"]=""
           CI_VARS["pr-target-git-branch-url"]=""
@@ -354,7 +354,7 @@ runs:
                   # Update resolved variables to point to PR head
                   CI_VARS["resolved-git-ref"]="refs/heads/$source_branch"
                   CI_VARS["resolved-git-branch"]="$source_branch"
-                  CI_VARS["resolved-repo-full-name"]="$source_repo"
+                  CI_VARS["resolved-repo-name-full"]="$source_repo"
                   CI_VARS["resolved-repo-owner"]="$source_owner"
                   CI_VARS["resolved-repo-name"]="$source_repo_name"
                   CI_VARS["resolved-git-branch-url"]="https://github.com/$source_repo/tree/$source_branch"

--- a/action.yml
+++ b/action.yml
@@ -245,17 +245,6 @@ runs:
           echo "Warning: GitHub CLI (gh) not available. PR resolution will be limited."
         fi
 
-    # Check GitHub CLI availability
-    - id: check-gh-cli
-      shell: bash
-      run: |
-        if command -v gh >/dev/null 2>&1; then
-          echo "gh-available=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "gh-available=false" >> "$GITHUB_OUTPUT"
-          echo "Warning: GitHub CLI (gh) not available. PR resolution will be limited."
-        fi
-
     # Process standard CI variables
     - id: resolve-standard-ci-vars
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -26,14 +26,103 @@ inputs:
   standard_ci_vars:
     description: >
       Whether to automatically resolve standard CI variables from GitHub context.
-      When enabled, variables like pr-number, head-ref, base-ref, etc. are automatically
+      When enabled, variables like pr-number, source-branch, target-branch, etc. are automatically
       populated based on the trigger type.
-    default: 'false'
+    default: 'true'
     required: false
 outputs:
   all:
     value: ${{ steps.merge-results.outputs.all_vars }}
     description: 'JSON-encoded object with all resolved values'
+  # Repository Context
+  repo:
+    value: ${{ steps.merge-results.outputs.repo }}
+    description: 'Target repository (base repo in owner/name format)'
+  target-repo:
+    value: ${{ steps.merge-results.outputs.target-repo }}
+    description: 'Target repository (base repo in owner/name format)'
+  repo-owner:
+    value: ${{ steps.merge-results.outputs.repo-owner }}
+    description: 'Repository owner/organization'
+  repo-name:
+    value: ${{ steps.merge-results.outputs.repo-name }}
+    description: 'Repository name only'
+  repo-name-full:
+    value: ${{ steps.merge-results.outputs.repo-name-full }}
+    description: 'Full repository name (owner/name)'
+  # Branch Context
+  source-branch:
+    value: ${{ steps.merge-results.outputs.source-branch }}
+    description: 'Source branch being merged (null for issues)'
+  target-branch:
+    value: ${{ steps.merge-results.outputs.target-branch }}
+    description: 'Target branch for merge (null for issues)'
+  source-repo:
+    value: ${{ steps.merge-results.outputs.source-repo }}
+    description: 'Source repository (important for forks, null for issues)'
+  # SHA Context
+  source-sha:
+    value: ${{ steps.merge-results.outputs.source-sha }}
+    description: 'Source commit SHA (null for issues)'
+  target-sha:
+    value: ${{ steps.merge-results.outputs.target-sha }}
+    description: 'Target commit SHA (null for issues)'
+  restricted-security-mode:
+    value: ${{ steps.merge-results.outputs.restricted-security-mode }}
+    description: 'Whether running in restricted security mode (fork/dependabot pull_request)'
+  # Pull Request Context
+  pr-number:
+    value: ${{ steps.merge-results.outputs.pr-number }}
+    description: 'Pull request number'
+  pr-title:
+    value: ${{ steps.merge-results.outputs.pr-title }}
+    description: 'Pull request title'
+  pr-author:
+    value: ${{ steps.merge-results.outputs.pr-author }}
+    description: 'Pull request author username'
+  pr-draft:
+    value: ${{ steps.merge-results.outputs.pr-draft }}
+    description: 'Whether PR is draft'
+  pr-from-fork:
+    value: ${{ steps.merge-results.outputs.pr-from-fork }}
+    description: 'Whether PR is from a fork'
+  # Issue Context
+  issue-number:
+    value: ${{ steps.merge-results.outputs.issue-number }}
+    description: 'Issue number (equals pr-number for PRs)'
+  issue-title:
+    value: ${{ steps.merge-results.outputs.issue-title }}
+    description: 'Issue title'
+  issue-author:
+    value: ${{ steps.merge-results.outputs.issue-author }}
+    description: 'Issue author username'
+  issue-type:
+    value: ${{ steps.merge-results.outputs.issue-type }}
+    description: 'Type of issue context (pull_request or issue)'
+  # Comment Context
+  comment-id:
+    value: ${{ steps.merge-results.outputs.comment-id }}
+    description: 'Comment ID that triggered workflow'
+  comment-author:
+    value: ${{ steps.merge-results.outputs.comment-author }}
+    description: 'Comment author username'
+  comment-body:
+    value: ${{ steps.merge-results.outputs.comment-body }}
+    description: 'Comment body text'
+  # Workflow Context
+  trigger-type:
+    value: ${{ steps.merge-results.outputs.trigger-type }}
+    description: 'Event that triggered workflow'
+  actor:
+    value: ${{ steps.merge-results.outputs.actor }}
+    description: 'User who triggered the workflow'
+  run-id:
+    value: ${{ steps.merge-results.outputs.run-id }}
+    description: 'Workflow run ID'
+  run-number:
+    value: ${{ steps.merge-results.outputs.run-number }}
+    description: 'Workflow run number'
+  # Legacy outputs
   var1:
     value: ${{ steps.merge-results.outputs.var1 }}
     description: 'Custom user-defined output variable 1'
@@ -138,74 +227,71 @@ runs:
         
         # Repository & Git Context
         CI_VARS["repo"]="${{ github.event.pull_request.base.repo.full_name || github.repository }}"
+        CI_VARS["target-repo"]="${{ github.event.pull_request.base.repo.full_name || github.repository }}"
         CI_VARS["repo-owner"]="${{ github.repository_owner }}"
-        CI_VARS["repo-name"]="${{ github.event.repository.name || github.repository }}"
+        repo_name="${{ github.event.repository.name }}"
+        if [[ -z "$repo_name" ]]; then
+          repo_name="${{ github.repository }}"
+          repo_name="${repo_name##*/}"
+        fi
+        CI_VARS["repo-name"]="$repo_name"
+        CI_VARS["repo-name-full"]="${{ github.event.pull_request.base.repo.full_name || github.repository }}"
         
         # Git refs - only populate for PR events, null for issue events and workflow_dispatch without pr input
         if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "pull_request_target" ]]; then
-          CI_VARS["head-ref"]="${{ github.head_ref || github.ref_name }}"
-          CI_VARS["base-ref"]="${{ github.base_ref || github.event.repository.default_branch || 'main' }}"
-          CI_VARS["head-repo"]="${{ github.event.pull_request.head.repo.full_name || github.repository }}"
-          CI_VARS["base-repo"]="${{ github.event.pull_request.base.repo.full_name || github.repository }}"
-          CI_VARS["head-sha"]="${{ github.event.pull_request.head.sha || github.sha }}"
-          CI_VARS["base-sha"]="${{ github.event.pull_request.base.sha }}"
+          CI_VARS["source-branch"]="${{ github.head_ref || github.ref_name }}"
+          CI_VARS["target-branch"]="${{ github.base_ref || github.event.repository.default_branch || 'main' }}"
+          CI_VARS["source-repo"]="${{ github.event.pull_request.head.repo.full_name || github.repository }}"
+          CI_VARS["source-sha"]="${{ github.event.pull_request.head.sha || github.sha }}"
+          CI_VARS["target-sha"]="${{ github.event.pull_request.base.sha }}"
         elif [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.pr }}" ]]; then
           # For workflow_dispatch with pr input, we can populate some refs but need to fetch PR data
-          CI_VARS["head-ref"]="${{ github.ref_name }}"  # This will be updated by gitref resolution
-          CI_VARS["base-ref"]="${{ github.event.repository.default_branch || 'main' }}"
-          CI_VARS["head-repo"]="${{ github.repository }}"
-          CI_VARS["base-repo"]="${{ github.repository }}"
-          CI_VARS["head-sha"]="${{ github.sha }}"
-          CI_VARS["base-sha"]=""  # Will be empty for workflow_dispatch
+          CI_VARS["source-branch"]="${{ github.ref_name }}"
+          CI_VARS["target-branch"]="${{ github.event.repository.default_branch || 'main' }}"
+          CI_VARS["source-repo"]="${{ github.repository }}"
+          CI_VARS["source-sha"]="${{ github.sha }}"
+          CI_VARS["target-sha"]=""
         elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-          # For workflow_dispatch without pr input, set both head-ref and base-ref to current branch
-          CI_VARS["head-ref"]="${{ github.ref_name }}"
-          CI_VARS["base-ref"]="${{ github.ref_name }}"
-          CI_VARS["head-repo"]="${{ github.repository }}"
-          CI_VARS["base-repo"]="${{ github.repository }}"
-          CI_VARS["head-sha"]="${{ github.sha }}"
-          CI_VARS["base-sha"]="${{ github.sha }}"
+          # For workflow_dispatch without pr input, set both source-branch and target-branch to current branch
+          CI_VARS["source-branch"]="${{ github.ref_name }}"
+          CI_VARS["target-branch"]="${{ github.ref_name }}"
+          CI_VARS["source-repo"]="${{ github.repository }}"
+          CI_VARS["source-sha"]="${{ github.sha }}"
+          CI_VARS["target-sha"]="${{ github.sha }}"
         else
           # For issue events, null out git refs since issues don't have branches
-          CI_VARS["head-ref"]=""
-          CI_VARS["base-ref"]=""
-          CI_VARS["head-repo"]=""
-          CI_VARS["base-repo"]=""
-          CI_VARS["head-sha"]=""
-          CI_VARS["base-sha"]=""
+          CI_VARS["source-branch"]=""
+          CI_VARS["target-branch"]=""
+          CI_VARS["source-repo"]=""
+          CI_VARS["source-sha"]=""
+          CI_VARS["target-sha"]=""
         fi
         
-        # Smart gitref resolution - ensures compatibility with repo variable
-        if [[ "${{ github.event_name }}" == "issues" || "${{ github.event_name }}" == "issue_comment" ]]; then
-          # For issue events, null out gitref since issues don't have branches
-          CI_VARS["gitref"]=""
-        elif [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "pull_request_target" ]]; then
-          # For PR events, gitref should be the head ref (fork's branch name only, not repo/branch)
-          # This ensures gitref is just the branch name that exists on head-repo
-          CI_VARS["gitref"]="${{ github.head_ref }}"
-        elif [[ -n "${{ inputs.pr }}" ]]; then
-          # When pr input exists (slash commands), fetch the PR head ref
-          # This handles slash commands that run from main but operate on PR branch
-          echo "Resolving gitref for PR ${{ inputs.pr }}..."
-          if command -v gh >/dev/null 2>&1; then
-            gitref=$(gh pr view "${{ inputs.pr }}" --json headRefName --jq '.headRefName' 2>/dev/null || echo "")
-            if [[ -n "$gitref" ]]; then
-              CI_VARS["gitref"]="$gitref"
-              # Also update head-repo to match the PR's head repo for consistency
-              head_repo=$(gh pr view "${{ inputs.pr }}" --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null || echo "")
-              if [[ -n "$head_repo" ]]; then
-                CI_VARS["head-repo"]="$head_repo"
+        # Smart source-branch resolution for workflow_dispatch with PR input
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.pr }}" ]]; then
+          # Validate PR input to prevent command injection
+          pr_input="${{ inputs.pr }}"
+          if [[ "$pr_input" =~ ^[0-9]+$ ]]; then
+            echo "Resolving source-branch for PR $pr_input..."
+            if command -v gh >/dev/null 2>&1; then
+              source_branch=$(gh pr view "$pr_input" --json headRefName --jq '.headRefName' 2>/dev/null || echo "")
+              if [[ -n "$source_branch" ]]; then
+                CI_VARS["source-branch"]="$source_branch"
+                # Also update source-repository to match the PR's head repo for consistency
+                source_repo=$(gh pr view "$pr_input" --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null || echo "")
+                if [[ -n "$source_repo" ]]; then
+                  CI_VARS["source-repo"]="$source_repo"
+                fi
+              else
+                CI_VARS["source-branch"]="${{ github.ref_name }}"
               fi
             else
-              CI_VARS["gitref"]="${{ github.ref_name }}"
+              CI_VARS["source-branch"]="${{ github.ref_name }}"
             fi
           else
-            CI_VARS["gitref"]="${{ github.ref_name }}"
+            echo "Warning: Invalid PR input '$pr_input'. Must be a PR number." >&2
+            CI_VARS["source-branch"]="${{ github.ref_name }}"
           fi
-        else
-          # For workflow_dispatch without pr input, gitref should match the current branch
-          # In this case, repo and gitref both refer to the same repository
-          CI_VARS["gitref"]="${{ github.ref_name }}"
         fi
         
         # Pull Request Variables
@@ -213,7 +299,7 @@ runs:
         CI_VARS["pr-title"]="${{ github.event.pull_request.title }}"
         CI_VARS["pr-author"]="${{ github.event.pull_request.user.login }}"
         CI_VARS["pr-draft"]="${{ github.event.pull_request.draft }}"
-        CI_VARS["is-pr-from-fork"]="${{ github.event.pull_request.head.repo.fork }}"
+        CI_VARS["pr-from-fork"]="${{ github.event.pull_request.head.repo.fork }}"
         
         # Issue Variables  
         CI_VARS["issue-number"]="${{ github.event.issue.number || github.event.pull_request.number }}"
@@ -231,6 +317,14 @@ runs:
         CI_VARS["actor"]="${{ github.actor }}"
         CI_VARS["run-id"]="${{ github.run_id }}"
         CI_VARS["run-number"]="${{ github.run_number }}"
+        
+        # Security Context
+        # restricted-security-mode is true when running from fork/dependabot and trigger is pull_request
+        if [[ "${{ github.event_name }}" == "pull_request" && ("${{ github.event.pull_request.head.repo.fork }}" == "true" || "${{ github.actor }}" == "dependabot[bot]") ]]; then
+          CI_VARS["restricted-security-mode"]="true"
+        else
+          CI_VARS["restricted-security-mode"]="false"
+        fi
         
         # Output each CI variable that has a value
         for var_name in "${!CI_VARS[@]}"; do

--- a/action.yml
+++ b/action.yml
@@ -23,13 +23,6 @@ inputs:
       Alias for log_outputs (true = show evaluated output)
     default: 'false'
     required: false
-  standard_ci_vars:
-    description: >
-      Whether to automatically resolve standard CI variables from GitHub context.
-      When enabled, variables like pr-number, source-branch, target-branch, etc. are automatically
-      populated based on the trigger type.
-    default: 'true'
-    required: false
 outputs:
   all:
     value: ${{ steps.merge-results.outputs.all_vars }}
@@ -218,9 +211,8 @@ runs:
         # Save initial JSON for potential jinja processing
         echo "INITIAL_JSON=$json_payload" >> "$GITHUB_ENV"
 
-    # Process standard CI variables if enabled
+    # Process standard CI variables
     - id: resolve-standard-ci-vars
-      if: ${{ inputs.standard_ci_vars == 'true' }}
       shell: bash
       run: |
         declare -A CI_VARS
@@ -441,8 +433,8 @@ runs:
           done <<< "${{ inputs.static_inputs }}"
         fi
 
-        # Add CI variables to RESOLVED_VARS if standard_ci_vars is enabled
-        if [[ "${{ inputs.standard_ci_vars }}" == "true" && -n "$CI_VARS_JSON" ]]; then
+        # Add CI variables to RESOLVED_VARS
+        if [[ -n "$CI_VARS_JSON" ]]; then
           echo "Adding standard CI variables..."
           # Parse CI_VARS_JSON and add to RESOLVED_VARS
           while IFS="=" read -r key value; do

--- a/action.yml
+++ b/action.yml
@@ -434,7 +434,9 @@ runs:
             ci_vars_json=$(echo "$ci_vars_json" | jq --arg key "$var_name" --arg value "$var_value" '. + {($key): $value}')
           fi
         done
-        echo "CI_VARS_JSON=$ci_vars_json" >> "$GITHUB_ENV"
+        # Make JSON compact for GITHUB_ENV
+        ci_vars_json_compact=$(echo "$ci_vars_json" | jq -c .)
+        echo "CI_VARS_JSON=$ci_vars_json_compact" >> "$GITHUB_ENV"
 
     # Process Jinja inputs using external action if jinja_inputs provided
     - id: process-jinja
@@ -563,23 +565,27 @@ runs:
           json_payload=$(echo "$json_payload" | jq --arg key "$var_name" --arg value "${RESOLVED_VARS[$var_name]}" '. + {($key): $value}')
         done
 
+        # Make JSON compact for GITHUB_OUTPUT
+        json_payload_compact=$(echo "$json_payload" | jq -c .)
         # Output the JSON object as 'custom'
-        echo "custom=$json_payload" >> "$GITHUB_OUTPUT"
+        echo "custom=$json_payload_compact" >> "$GITHUB_OUTPUT"
 
-        # Logging
+        # Logging with emoji grouping for better scanability
         SHOULD_LOG="${{ inputs.log_outputs == 'true' || inputs.non_sensitive == 'true' }}"
         if [[ "$SHOULD_LOG" == "true" ]]; then
+          echo "🔧 ===== Variable Resolution Results ====="
           echo "✅ Resolved variables:"
           for var_name in "${!RESOLVED_VARS[@]}"; do
-            echo "  $var_name: ${RESOLVED_VARS[$var_name]}"
+            echo "  📝 $var_name: ${RESOLVED_VARS[$var_name]}"
           done
-          echo "  custom (JSON): $json_payload"
+          echo "  📦 custom (JSON): $json_payload_compact"
+          echo "🔧 ===== End Variable Resolution ====="
 
           {
             echo "### 🔍 Variable Resolution Summary"
             for var_name in "${!RESOLVED_VARS[@]}"; do
-              echo "- \`$var_name\`: ${RESOLVED_VARS[$var_name]}"
+              echo "- 📝 \`$var_name\`: ${RESOLVED_VARS[$var_name]}"
             done
-            echo "- \`custom\`: $json_payload"
+            echo "- 📦 \`custom\`: $json_payload_compact"
           } >> "$GITHUB_STEP_SUMMARY"
         fi

--- a/action.yml
+++ b/action.yml
@@ -234,6 +234,28 @@ runs:
         # Save initial JSON for potential jinja processing
         echo "INITIAL_JSON=$json_payload" >> "$GITHUB_ENV"
 
+    # Check GitHub CLI availability
+    - id: check-gh-cli
+      shell: bash
+      run: |
+        if command -v gh >/dev/null 2>&1; then
+          echo "gh-available=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "gh-available=false" >> "$GITHUB_OUTPUT"
+          echo "Warning: GitHub CLI (gh) not available. PR resolution will be limited."
+        fi
+
+    # Check GitHub CLI availability
+    - id: check-gh-cli
+      shell: bash
+      run: |
+        if command -v gh >/dev/null 2>&1; then
+          echo "gh-available=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "gh-available=false" >> "$GITHUB_OUTPUT"
+          echo "Warning: GitHub CLI (gh) not available. PR resolution will be limited."
+        fi
+
     # Process standard CI variables
     - id: resolve-standard-ci-vars
       shell: bash
@@ -301,7 +323,7 @@ runs:
           CI_VARS["pr-target-repo-name"]="${{ github.event.pull_request.base.repo.name }}"
           CI_VARS["pr-target-git-branch-url"]="https://github.com/${CI_VARS["pr-target-repo-full-name"]}/tree/${CI_VARS["pr-target-git-branch"]}"
           CI_VARS["pr-target-git-commit-url"]="https://github.com/${CI_VARS["pr-target-repo-full-name"]}/commit/${CI_VARS["pr-target-git-sha"]}"
-          CI_VARS["pr-target-git-tag"]=""  # PRs typically don't target tags
+          CI_VARS["pr-target-git-tag"]=""
         else
           # For non-PR events, null out PR-specific variables
           CI_VARS["pr-source-git-ref"]=""
@@ -330,7 +352,7 @@ runs:
           pr_input="${{ inputs.pr }}"
           if [[ "$pr_input" =~ ^[0-9]+$ ]] || [[ "$pr_input" =~ ^https://github\.com/[^/]+/[^/]+/pull/[0-9]+$ ]]; then
             echo "Resolving PR data for PR $pr_input..."
-            if command -v gh >/dev/null 2>&1; then
+            if [[ "${{ steps.check-gh-cli.outputs.gh-available }}" == "true" ]]; then
               # Fetch PR data and update resolved variables to point to PR head
               pr_data=$(gh pr view "$pr_input" --json headRefName,headRepository,headRepositoryOwner 2>/dev/null || echo "")
               if [[ -n "$pr_data" ]]; then
@@ -550,8 +572,8 @@ runs:
         done
         json_payload+="}"
 
-        # Output the JSON object as 'all_vars'
-        echo "all_vars=$json_payload" >> "$GITHUB_OUTPUT"
+        # Output the JSON object as 'custom'
+        echo "custom=$json_payload" >> "$GITHUB_OUTPUT"
 
         # Logging
         SHOULD_LOG="${{ inputs.log_outputs == 'true' || inputs.non_sensitive == 'true' }}"
@@ -560,13 +582,13 @@ runs:
           for var_name in "${!RESOLVED_VARS[@]}"; do
             echo "  $var_name: ${RESOLVED_VARS[$var_name]}"
           done
-          echo "  all_vars (JSON): $json_payload"
+          echo "  custom (JSON): $json_payload"
 
           {
             echo "### 🔍 Variable Resolution Summary"
             for var_name in "${!RESOLVED_VARS[@]}"; do
               echo "- \`$var_name\`: ${RESOLVED_VARS[$var_name]}"
             done
-            echo "- \`all_vars\`: $json_payload"
+            echo "- \`custom\`: $json_payload"
           } >> "$GITHUB_STEP_SUMMARY"
         fi

--- a/action.yml
+++ b/action.yml
@@ -24,97 +24,120 @@ inputs:
     default: 'false'
     required: false
 outputs:
-  all:
+  custom:
     value: ${{ steps.merge-results.outputs.all_vars }}
     description: 'JSON-encoded object with all resolved values'
-  # Repository Context
-  repo:
-    value: ${{ steps.merge-results.outputs.repo }}
-    description: 'Target repository (base repo in owner/name format)'
-  target-repo:
-    value: ${{ steps.merge-results.outputs.target-repo }}
-    description: 'Target repository (base repo in owner/name format)'
-  repo-owner:
-    value: ${{ steps.merge-results.outputs.repo-owner }}
-    description: 'Repository owner/organization'
-  repo-name:
-    value: ${{ steps.merge-results.outputs.repo-name }}
-    description: 'Repository name only'
-  repo-name-full:
-    value: ${{ steps.merge-results.outputs.repo-name-full }}
-    description: 'Full repository name (owner/name)'
-  # Branch Context
-  source-branch:
-    value: ${{ steps.merge-results.outputs.source-branch }}
-    description: 'Source branch being merged (null for issues)'
-  target-branch:
-    value: ${{ steps.merge-results.outputs.target-branch }}
-    description: 'Target branch for merge (null for issues)'
-  source-repo:
-    value: ${{ steps.merge-results.outputs.source-repo }}
-    description: 'Source repository (important for forks, null for issues)'
-  # SHA Context
-  source-sha:
-    value: ${{ steps.merge-results.outputs.source-sha }}
-    description: 'Source commit SHA (null for issues)'
-  target-sha:
-    value: ${{ steps.merge-results.outputs.target-sha }}
-    description: 'Target commit SHA (null for issues)'
-  restricted-security-mode:
-    value: ${{ steps.merge-results.outputs.restricted-security-mode }}
-    description: 'Whether running in restricted security mode (fork/dependabot pull_request)'
-  # Pull Request Context
+  # Resolved Variables (always the effective context)
+  resolved-git-ref:
+    value: ${{ steps.merge-results.outputs.resolved-git-ref }}
+    description: 'Full Git ref (refs/heads/... or refs/tags/...)'
+  resolved-git-branch:
+    value: ${{ steps.merge-results.outputs.resolved-git-branch }}
+    description: 'Short branch name (e.g. main, feature/foo)'
+  resolved-git-sha:
+    value: ${{ steps.merge-results.outputs.resolved-git-sha }}
+    description: 'Commit SHA'
+  resolved-git-tag:
+    value: ${{ steps.merge-results.outputs.resolved-git-tag }}
+    description: 'Tag name (if applicable)'
+  resolved-repo-name:
+    value: ${{ steps.merge-results.outputs.resolved-repo-name }}
+    description: 'Repository name (e.g. my-repo)'
+  resolved-repo-owner:
+    value: ${{ steps.merge-results.outputs.resolved-repo-owner }}
+    description: 'Repository owner (user or org)'
+  resolved-repo-full-name:
+    value: ${{ steps.merge-results.outputs.resolved-repo-full-name }}
+    description: 'Owner + name (e.g. myorg/my-repo)'
+  resolved-git-branch-url:
+    value: ${{ steps.merge-results.outputs.resolved-git-branch-url }}
+    description: 'URL to the branch in GitHub'
+  resolved-git-commit-url:
+    value: ${{ steps.merge-results.outputs.resolved-git-commit-url }}
+    description: 'URL to the commit in GitHub'
+  # PR Source Variables
+  pr-source-git-ref:
+    value: ${{ steps.merge-results.outputs.pr-source-git-ref }}
+    description: 'Git ref of the source (PR head)'
+  pr-source-git-branch:
+    value: ${{ steps.merge-results.outputs.pr-source-git-branch }}
+    description: 'Branch name of the source'
+  pr-source-git-sha:
+    value: ${{ steps.merge-results.outputs.pr-source-git-sha }}
+    description: 'SHA of the source commit'
+  pr-source-repo-name:
+    value: ${{ steps.merge-results.outputs.pr-source-repo-name }}
+    description: 'Source repo name'
+  pr-source-repo-owner:
+    value: ${{ steps.merge-results.outputs.pr-source-repo-owner }}
+    description: 'Source repo owner'
+  pr-source-repo-full-name:
+    value: ${{ steps.merge-results.outputs.pr-source-repo-full-name }}
+    description: 'Full source repo name (owner/name)'
+  pr-source-git-branch-url:
+    value: ${{ steps.merge-results.outputs.pr-source-git-branch-url }}
+    description: 'URL to the source branch'
+  pr-source-git-commit-url:
+    value: ${{ steps.merge-results.outputs.pr-source-git-commit-url }}
+    description: 'URL to the source commit'
+  pr-source-is-fork:
+    value: ${{ steps.merge-results.outputs.pr-source-is-fork }}
+    description: 'Whether the source repo is a fork'
+  # PR Target Variables
+  pr-target-git-ref:
+    value: ${{ steps.merge-results.outputs.pr-target-git-ref }}
+    description: 'Git ref of the target (PR base)'
+  pr-target-git-branch:
+    value: ${{ steps.merge-results.outputs.pr-target-git-branch }}
+    description: 'Branch name of the target'
+  pr-target-git-sha:
+    value: ${{ steps.merge-results.outputs.pr-target-git-sha }}
+    description: 'SHA of the target commit'
+  pr-target-git-tag:
+    value: ${{ steps.merge-results.outputs.pr-target-git-tag }}
+    description: 'Tag name, if PR targets a tag'
+  pr-target-repo-name:
+    value: ${{ steps.merge-results.outputs.pr-target-repo-name }}
+    description: 'Target repo name'
+  pr-target-repo-owner:
+    value: ${{ steps.merge-results.outputs.pr-target-repo-owner }}
+    description: 'Target repo owner'
+  pr-target-repo-full-name:
+    value: ${{ steps.merge-results.outputs.pr-target-repo-full-name }}
+    description: 'Full target repo name (owner/name)'
+  pr-target-git-branch-url:
+    value: ${{ steps.merge-results.outputs.pr-target-git-branch-url }}
+    description: 'URL to the target branch'
+  pr-target-git-commit-url:
+    value: ${{ steps.merge-results.outputs.pr-target-git-commit-url }}
+    description: 'URL to the target commit'
+  # PR Variables
   pr-number:
     value: ${{ steps.merge-results.outputs.pr-number }}
-    description: 'Pull request number'
+    description: 'Pull request number (if applicable)'
+  pr-url:
+    value: ${{ steps.merge-results.outputs.pr-url }}
+    description: 'URL to the pull request'
   pr-title:
     value: ${{ steps.merge-results.outputs.pr-title }}
-    description: 'Pull request title'
-  pr-author:
-    value: ${{ steps.merge-results.outputs.pr-author }}
-    description: 'Pull request author username'
-  pr-draft:
-    value: ${{ steps.merge-results.outputs.pr-draft }}
-    description: 'Whether PR is draft'
-  pr-from-fork:
-    value: ${{ steps.merge-results.outputs.pr-from-fork }}
-    description: 'Whether PR is from a fork'
-  # Issue Context
-  issue-number:
-    value: ${{ steps.merge-results.outputs.issue-number }}
-    description: 'Issue number (equals pr-number for PRs)'
-  issue-title:
-    value: ${{ steps.merge-results.outputs.issue-title }}
-    description: 'Issue title'
-  issue-author:
-    value: ${{ steps.merge-results.outputs.issue-author }}
-    description: 'Issue author username'
-  issue-type:
-    value: ${{ steps.merge-results.outputs.issue-type }}
-    description: 'Type of issue context (pull_request or issue)'
-  # Comment Context
+    description: 'Title of the pull request'
+  # Comment Variables
   comment-id:
     value: ${{ steps.merge-results.outputs.comment-id }}
-    description: 'Comment ID that triggered workflow'
-  comment-author:
-    value: ${{ steps.merge-results.outputs.comment-author }}
-    description: 'Comment author username'
-  comment-body:
-    value: ${{ steps.merge-results.outputs.comment-body }}
-    description: 'Comment body text'
-  # Workflow Context
-  trigger-type:
-    value: ${{ steps.merge-results.outputs.trigger-type }}
-    description: 'Event that triggered workflow'
-  actor:
-    value: ${{ steps.merge-results.outputs.actor }}
-    description: 'User who triggered the workflow'
+    description: 'ID of the triggering comment (if applicable)'
+  comment-url:
+    value: ${{ steps.merge-results.outputs.comment-url }}
+    description: 'URL to the triggering comment (if applicable)'
+  # Additional Resolved Metadata
   run-id:
     value: ${{ steps.merge-results.outputs.run-id }}
-    description: 'Workflow run ID'
-  run-number:
-    value: ${{ steps.merge-results.outputs.run-number }}
-    description: 'Workflow run number'
+    description: 'GitHub Actions run ID'
+  run-url:
+    value: ${{ steps.merge-results.outputs.run-url }}
+    description: 'URL to the GitHub Actions run'
+  is-pr:
+    value: ${{ steps.merge-results.outputs.is-pr }}
+    description: 'Boolean: whether the current context is a PR'
   # Legacy outputs
   var1:
     value: ${{ steps.merge-results.outputs.var1 }}
@@ -217,105 +240,147 @@ runs:
       run: |
         declare -A CI_VARS
         
-        # Repository & Git Context
-        CI_VARS["repo"]="${{ github.event.pull_request.base.repo.full_name || github.repository }}"
-        CI_VARS["target-repo"]="${{ github.event.pull_request.base.repo.full_name || github.repository }}"
-        CI_VARS["repo-owner"]="${{ github.repository_owner }}"
-        repo_name="${{ github.event.repository.name }}"
-        if [[ -z "$repo_name" ]]; then
-          repo_full="${{ github.repository }}"
-          repo_name="${repo_full##*/}"
-        fi
-        CI_VARS["repo-name"]="$repo_name"
-        CI_VARS["repo-name-full"]="${{ github.event.pull_request.base.repo.full_name || github.repository }}"
-        
-        # Git refs - only populate for PR events, null for issue events and workflow_dispatch without pr input
+        # Resolved Variables (always the effective context)
+        # For PRs: resolved = source (head), for other contexts: resolved = current
         if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "pull_request_target" ]]; then
-          CI_VARS["source-branch"]="${{ github.head_ref || github.ref_name }}"
-          CI_VARS["target-branch"]="${{ github.base_ref || github.event.repository.default_branch || 'main' }}"
-          CI_VARS["source-repo"]="${{ github.event.pull_request.head.repo.full_name || github.repository }}"
-          CI_VARS["source-sha"]="${{ github.event.pull_request.head.sha || github.sha }}"
-          CI_VARS["target-sha"]="${{ github.event.pull_request.base.sha }}"
-        elif [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.pr }}" ]]; then
-          # For workflow_dispatch with pr input, we can populate some refs but need to fetch PR data
-          CI_VARS["source-branch"]="${{ github.ref_name }}"
-          CI_VARS["target-branch"]="${{ github.event.repository.default_branch || 'main' }}"
-          CI_VARS["source-repo"]="${{ github.repository }}"
-          CI_VARS["source-sha"]="${{ github.sha }}"
-          CI_VARS["target-sha"]=""
-        elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-          # For workflow_dispatch without pr input, set both source-branch and target-branch to current branch
-          CI_VARS["source-branch"]="${{ github.ref_name }}"
-          CI_VARS["target-branch"]="${{ github.ref_name }}"
-          CI_VARS["source-repo"]="${{ github.repository }}"
-          CI_VARS["source-sha"]="${{ github.sha }}"
-          CI_VARS["target-sha"]="${{ github.sha }}"
+          CI_VARS["resolved-git-ref"]="refs/heads/${{ github.head_ref || github.ref_name }}"
+          CI_VARS["resolved-git-branch"]="${{ github.head_ref || github.ref_name }}"
+          CI_VARS["resolved-git-sha"]="${{ github.event.pull_request.head.sha || github.sha }}"
+          CI_VARS["resolved-repo-full-name"]="${{ github.event.pull_request.head.repo.full_name || github.repository }}"
+          CI_VARS["resolved-repo-owner"]="${{ github.event.pull_request.head.repo.owner.login || github.repository_owner }}"
+          resolved_repo_name="${{ github.event.pull_request.head.repo.name }}"
+          if [[ -z "$resolved_repo_name" ]]; then
+            resolved_repo_full="${{ github.event.pull_request.head.repo.full_name || github.repository }}"
+            resolved_repo_name="${resolved_repo_full##*/}"
+          fi
+          CI_VARS["resolved-repo-name"]="$resolved_repo_name"
         else
-          # For issue events, null out git refs since issues don't have branches
-          CI_VARS["source-branch"]=""
-          CI_VARS["target-branch"]=""
-          CI_VARS["source-repo"]=""
-          CI_VARS["source-sha"]=""
-          CI_VARS["target-sha"]=""
+          CI_VARS["resolved-git-ref"]="${{ github.ref }}"
+          CI_VARS["resolved-git-branch"]="${{ github.ref_name }}"
+          CI_VARS["resolved-git-sha"]="${{ github.sha }}"
+          CI_VARS["resolved-repo-full-name"]="${{ github.repository }}"
+          CI_VARS["resolved-repo-owner"]="${{ github.repository_owner }}"
+          repo_name="${{ github.event.repository.name }}"
+          if [[ -z "$repo_name" ]]; then
+            repo_full="${{ github.repository }}"
+            repo_name="${repo_full##*/}"
+          fi
+          CI_VARS["resolved-repo-name"]="$repo_name"
         fi
         
-        # Smart source-branch resolution for workflow_dispatch with PR input
+        # Generate URLs for resolved context
+        CI_VARS["resolved-git-branch-url"]="https://github.com/${CI_VARS["resolved-repo-full-name"]}/tree/${CI_VARS["resolved-git-branch"]}"
+        CI_VARS["resolved-git-commit-url"]="https://github.com/${CI_VARS["resolved-repo-full-name"]}/commit/${CI_VARS["resolved-git-sha"]}"
+        
+        # Git tag (if applicable)
+        if [[ "${{ github.ref }}" =~ ^refs/tags/ ]]; then
+          CI_VARS["resolved-git-tag"]="${{ github.ref_name }}"
+        else
+          CI_VARS["resolved-git-tag"]=""
+        fi
+        
+        # PR Source and Target Variables (only for PR events)
+        if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "pull_request_target" ]]; then
+          # PR Source (head)
+          CI_VARS["pr-source-git-ref"]="refs/heads/${{ github.head_ref }}"
+          CI_VARS["pr-source-git-branch"]="${{ github.head_ref }}"
+          CI_VARS["pr-source-git-sha"]="${{ github.event.pull_request.head.sha }}"
+          CI_VARS["pr-source-repo-full-name"]="${{ github.event.pull_request.head.repo.full_name }}"
+          CI_VARS["pr-source-repo-owner"]="${{ github.event.pull_request.head.repo.owner.login }}"
+          CI_VARS["pr-source-repo-name"]="${{ github.event.pull_request.head.repo.name }}"
+          CI_VARS["pr-source-is-fork"]="${{ github.event.pull_request.head.repo.fork }}"
+          CI_VARS["pr-source-git-branch-url"]="https://github.com/${CI_VARS["pr-source-repo-full-name"]}/tree/${CI_VARS["pr-source-git-branch"]}"
+          CI_VARS["pr-source-git-commit-url"]="https://github.com/${CI_VARS["pr-source-repo-full-name"]}/commit/${CI_VARS["pr-source-git-sha"]}"
+          
+          # PR Target (base)
+          CI_VARS["pr-target-git-ref"]="refs/heads/${{ github.base_ref }}"
+          CI_VARS["pr-target-git-branch"]="${{ github.base_ref }}"
+          CI_VARS["pr-target-git-sha"]="${{ github.event.pull_request.base.sha }}"
+          CI_VARS["pr-target-repo-full-name"]="${{ github.event.pull_request.base.repo.full_name }}"
+          CI_VARS["pr-target-repo-owner"]="${{ github.event.pull_request.base.repo.owner.login }}"
+          CI_VARS["pr-target-repo-name"]="${{ github.event.pull_request.base.repo.name }}"
+          CI_VARS["pr-target-git-branch-url"]="https://github.com/${CI_VARS["pr-target-repo-full-name"]}/tree/${CI_VARS["pr-target-git-branch"]}"
+          CI_VARS["pr-target-git-commit-url"]="https://github.com/${CI_VARS["pr-target-repo-full-name"]}/commit/${CI_VARS["pr-target-git-sha"]}"
+          CI_VARS["pr-target-git-tag"]=""  # PRs typically don't target tags
+        else
+          # For non-PR events, null out PR-specific variables
+          CI_VARS["pr-source-git-ref"]=""
+          CI_VARS["pr-source-git-branch"]=""
+          CI_VARS["pr-source-git-sha"]=""
+          CI_VARS["pr-source-repo-full-name"]=""
+          CI_VARS["pr-source-repo-owner"]=""
+          CI_VARS["pr-source-repo-name"]=""
+          CI_VARS["pr-source-is-fork"]=""
+          CI_VARS["pr-source-git-branch-url"]=""
+          CI_VARS["pr-source-git-commit-url"]=""
+          CI_VARS["pr-target-git-ref"]=""
+          CI_VARS["pr-target-git-branch"]=""
+          CI_VARS["pr-target-git-sha"]=""
+          CI_VARS["pr-target-repo-full-name"]=""
+          CI_VARS["pr-target-repo-owner"]=""
+          CI_VARS["pr-target-repo-name"]=""
+          CI_VARS["pr-target-git-branch-url"]=""
+          CI_VARS["pr-target-git-commit-url"]=""
+          CI_VARS["pr-target-git-tag"]=""
+        fi
+        
+        # Smart resolution for workflow_dispatch with PR input
         if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.pr }}" ]]; then
           # Validate PR input to prevent command injection
           pr_input="${{ inputs.pr }}"
           if [[ "$pr_input" =~ ^[0-9]+$ ]] || [[ "$pr_input" =~ ^https://github\.com/[^/]+/[^/]+/pull/[0-9]+$ ]]; then
-            echo "Resolving source-branch for PR $pr_input..."
+            echo "Resolving PR data for PR $pr_input..."
             if command -v gh >/dev/null 2>&1; then
-              source_branch=$(gh pr view "$pr_input" --json headRefName --jq '.headRefName' 2>/dev/null || echo "")
-              if [[ -n "$source_branch" ]]; then
-                CI_VARS["source-branch"]="$source_branch"
-                # Also update source-repo to match the PR's head repo for consistency
-                source_repo=$(gh pr view "$pr_input" --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null || echo "")
-                if [[ -n "$source_repo" ]]; then
-                  CI_VARS["source-repo"]="$source_repo"
+              # Fetch PR data and update resolved variables to point to PR head
+              pr_data=$(gh pr view "$pr_input" --json headRefName,headRepository,headRepositoryOwner 2>/dev/null || echo "")
+              if [[ -n "$pr_data" ]]; then
+                source_branch=$(echo "$pr_data" | jq -r '.headRefName // empty')
+                source_repo=$(echo "$pr_data" | jq -r '.headRepository.nameWithOwner // empty')
+                source_owner=$(echo "$pr_data" | jq -r '.headRepositoryOwner.login // empty')
+                source_repo_name=$(echo "$pr_data" | jq -r '.headRepository.name // empty')
+                
+                if [[ -n "$source_branch" ]]; then
+                  # Update resolved variables to point to PR head
+                  CI_VARS["resolved-git-ref"]="refs/heads/$source_branch"
+                  CI_VARS["resolved-git-branch"]="$source_branch"
+                  CI_VARS["resolved-repo-full-name"]="$source_repo"
+                  CI_VARS["resolved-repo-owner"]="$source_owner"
+                  CI_VARS["resolved-repo-name"]="$source_repo_name"
+                  CI_VARS["resolved-git-branch-url"]="https://github.com/$source_repo/tree/$source_branch"
                 fi
-              else
-                CI_VARS["source-branch"]="${{ github.ref_name }}"
               fi
-            else
-              CI_VARS["source-branch"]="${{ github.ref_name }}"
             fi
           else
             echo "Error: Invalid PR input '$pr_input'. Must be a PR number or valid PR URL." >&2
-            CI_VARS["source-branch"]="${{ github.ref_name }}"
           fi
         fi
         
-        # Pull Request Variables
+        # PR Variables
         CI_VARS["pr-number"]="${{ github.event.pull_request.number || github.event.issue.number }}"
         CI_VARS["pr-title"]="${{ github.event.pull_request.title }}"
-        CI_VARS["pr-author"]="${{ github.event.pull_request.user.login }}"
-        CI_VARS["pr-draft"]="${{ github.event.pull_request.draft }}"
-        CI_VARS["pr-from-fork"]="${{ github.event.pull_request.head.repo.fork }}"
-        
-        # Issue Variables  
-        CI_VARS["issue-number"]="${{ github.event.issue.number || github.event.pull_request.number }}"
-        CI_VARS["issue-title"]="${{ github.event.issue.title || github.event.pull_request.title }}"
-        CI_VARS["issue-author"]="${{ github.event.issue.user.login || github.event.pull_request.user.login }}"
-        CI_VARS["issue-type"]="${{ github.event.pull_request && 'pull_request' || 'issue' }}"
+        if [[ -n "${{ github.event.pull_request.number }}" ]]; then
+          CI_VARS["pr-url"]="https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+        else
+          CI_VARS["pr-url"]=""
+        fi
         
         # Comment Variables
         CI_VARS["comment-id"]="${{ github.event.comment.id }}"
-        CI_VARS["comment-author"]="${{ github.event.comment.user.login }}"
-        CI_VARS["comment-body"]="${{ github.event.comment.body }}"
-        
-        # Workflow Context
-        CI_VARS["trigger-type"]="${{ github.event_name }}"
-        CI_VARS["actor"]="${{ github.actor }}"
-        CI_VARS["run-id"]="${{ github.run_id }}"
-        CI_VARS["run-number"]="${{ github.run_number }}"
-        
-        # Security Context
-        # restricted-security-mode is true when running from fork/dependabot and trigger is pull_request
-        if [[ "${{ github.event_name }}" == "pull_request" && ("${{ github.event.pull_request.head.repo.fork }}" == "true" || "${{ github.actor }}" == "dependabot[bot]") ]]; then
-          CI_VARS["restricted-security-mode"]="true"
+        if [[ -n "${{ github.event.comment.id }}" ]]; then
+          CI_VARS["comment-url"]="https://github.com/${{ github.repository }}/issues/${{ github.event.issue.number || github.event.pull_request.number }}#issuecomment-${{ github.event.comment.id }}"
         else
-          CI_VARS["restricted-security-mode"]="false"
+          CI_VARS["comment-url"]=""
+        fi
+        
+        # Additional Resolved Metadata
+        CI_VARS["run-id"]="${{ github.run_id }}"
+        CI_VARS["run-url"]="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        
+        # Boolean: whether current context is a PR
+        if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "pull_request_target" ]]; then
+          CI_VARS["is-pr"]="true"
+        else
+          CI_VARS["is-pr"]="false"
         fi
         
         # Output each CI variable that has a value

--- a/action.yml
+++ b/action.yml
@@ -236,6 +236,8 @@ runs:
         fi
         CI_VARS["repo-name"]="$repo_name"
         CI_VARS["repo-name-full"]="${{ github.event.pull_request.base.repo.full_name || github.repository }}"
+        CI_VARS["repo-name-full"]="${{ github.event.pull_request.base.repo.full_name || github.repository }}"
+        CI_VARS["repo-name-full"]="${{ github.event.pull_request.base.repo.full_name || github.repository }}"
         
         # Git refs - only populate for PR events, null for issue events and workflow_dispatch without pr input
         if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "pull_request_target" ]]; then
@@ -332,6 +334,9 @@ runs:
           if [[ -n "$var_value" && "$var_value" != "null" && "$var_value" != "" ]]; then
             echo "$var_name=$var_value" >> "$GITHUB_OUTPUT"
             echo "Resolved CI variable: $var_name = $var_value"
+          else
+            echo "$var_name=" >> "$GITHUB_OUTPUT"
+            echo "Resolved CI variable: $var_name = (empty)"
           fi
         done
         

--- a/action.yml
+++ b/action.yml
@@ -175,29 +175,36 @@ runs:
           CI_VARS["base-sha"]=""
         fi
         
-        # Smart gitref resolution - handles "run from main, operate on PR branch" pattern
+        # Smart gitref resolution - ensures compatibility with repo variable
         if [[ "${{ github.event_name }}" == "issues" || "${{ github.event_name }}" == "issue_comment" ]]; then
           # For issue events, null out gitref since issues don't have branches
           CI_VARS["gitref"]=""
+        elif [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "pull_request_target" ]]; then
+          # For PR events, gitref should be the head ref (fork's branch name only, not repo/branch)
+          # This ensures gitref is just the branch name that exists on head-repo
+          CI_VARS["gitref"]="${{ github.head_ref }}"
         elif [[ -n "${{ inputs.pr }}" ]]; then
-          # When pr input exists, we need to fetch the actual PR head ref (fork's branch)
+          # When pr input exists (slash commands), fetch the PR head ref
           # This handles slash commands that run from main but operate on PR branch
           echo "Resolving gitref for PR ${{ inputs.pr }}..."
           if command -v gh >/dev/null 2>&1; then
             gitref=$(gh pr view "${{ inputs.pr }}" --json headRefName --jq '.headRefName' 2>/dev/null || echo "")
             if [[ -n "$gitref" ]]; then
               CI_VARS["gitref"]="$gitref"
+              # Also update head-repo to match the PR's head repo for consistency
+              head_repo=$(gh pr view "${{ inputs.pr }}" --json headRepository --jq '.headRepository.nameWithOwner' 2>/dev/null || echo "")
+              if [[ -n "$head_repo" ]]; then
+                CI_VARS["head-repo"]="$head_repo"
+              fi
             else
-              CI_VARS["gitref"]="${{ github.head_ref || github.ref_name }}"
+              CI_VARS["gitref"]="${{ github.ref_name }}"
             fi
           else
-            CI_VARS["gitref"]="${{ github.head_ref || github.ref_name }}"
+            CI_VARS["gitref"]="${{ github.ref_name }}"
           fi
-        elif [[ -n "${{ github.head_ref }}" ]]; then
-          # For direct PR events - use head ref (fork's branch)
-          CI_VARS["gitref"]="${{ github.head_ref }}"
         else
-          # Fallback to current ref (for workflow_dispatch without pr input)
+          # For workflow_dispatch without pr input, gitref should match the current branch
+          # In this case, repo and gitref both refer to the same repository
           CI_VARS["gitref"]="${{ github.ref_name }}"
         fi
         
@@ -345,6 +352,8 @@ runs:
             if [[ -n "$key" && -n "$value" ]]; then
               RESOLVED_VARS["$key"]="$value"
               echo "Added CI variable: $key = $value"
+              # Also output as individual GitHub Action output
+              echo "$key=$value" >> "$GITHUB_OUTPUT"
             fi
           done < <(echo "$CI_VARS_JSON" | jq -r 'to_entries[] | "\(.key)=\(.value)"' 2>/dev/null || echo "")
         fi


### PR DESCRIPTION
# feat: Add automatic standard CI variable resolution

## Summary

This PR implements automatic resolution of standard CI variables from GitHub context, eliminating the need for complex expressions like `${{ github.event.pull_request.head.repo.full_name || github.repository }}` throughout workflows.

**Key Changes:**
- Added `standard_ci_vars` input parameter (default: false) to enable the feature
- Implements resolution for 20+ standard variables: `pr-number`, `head-ref`, `base-ref`, `repo`, `head-repo`, `base-repo`, etc.
- Smart `gitref` resolution handles "run from main, operate on PR branch" pattern for slash commands
- Fork-aware: `repo` variables point to base repository, `gitref` points to fork's branch
- Issue-aware: Git refs are null for issue events since issues don't have branches
- Maintains full backward compatibility with existing functionality

## Review & Testing Checklist for Human

- [ ] **Test with actual fork PRs** - Verify `repo` resolves to base repo while `gitref` resolves to fork's branch name
- [ ] **Test slash commands from different contexts** - Verify workflow_dispatch with/without `pr` input resolves variables correctly  
- [ ] **Test issue vs PR trigger scenarios** - Confirm git refs are null for issue events but populated for PR events
- [ ] **Verify backward compatibility** - Run existing workflows with `standard_ci_vars: false` to ensure no regressions
- [ ] **Test edge cases** - Missing PR data, gh CLI unavailable, workflow_dispatch without clear context

**Recommended Test Plan:**
1. Create a fork PR and trigger workflows to verify repo vs gitref resolution
2. Test slash commands (`/test`, etc.) to ensure smart gitref fetches correct branch
3. Run action on issue comments to verify git refs are properly nulled
4. Test with existing workflows to confirm no breaking changes

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A["action.yml"]:::major-edit --> B["resolve-standard-ci-vars step"]:::major-edit
    A --> C["merge-results step"]:::minor-edit
    D["README.md"]:::major-edit --> E["Standard CI Variables table"]:::major-edit
    F[".github/workflows/test-action.yml"]:::major-edit --> G["test-standard-ci-vars job"]:::major-edit
    
    B --> H["GitHub Context<br/>(github.event.*)"]:::context
    B --> I["Smart gitref resolution<br/>(gh pr view)"]:::context
    C --> J["Final JSON output<br/>(all variables)"]:::context
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- The smart gitref resolution using `gh pr view` has fallback logic but may need testing in constrained CI environments
- Fork handling logic is critical - ensure `repo` (base) vs `gitref` (head) distinction works correctly
- Requested by AJ Steers (@aaronsteers)  
- Session: https://app.devin.ai/sessions/2ea6e9db29ce437d8ca81c377c8660b8
- Link to Devin run: https://app.devin.ai/sessions/2ea6e9db29ce437d8ca81c377c8660b8