### PR TITLE
ci: fix release drafter race condition

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: release-drafter
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -16,7 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts the next Release notes as Pull Requests are merged into "main"
-      - uses: release-drafter/release-drafter@v6
+      # Pinned to v6.0.0 to avoid v6.1.0 bug: https://github.com/release-drafter/release-drafter/issues/1425
+      - uses: release-drafter/release-drafter@v6.0.0
         with:
           config-name: release-drafter.yml
           disable-autolabeler: true


### PR DESCRIPTION
## Summary

Fixes a race condition in the release-drafter workflow where merged PRs sometimes don't appear in the draft release notes when multiple PRs merge in quick succession.

**Changes:**
1. Add `concurrency` group with `cancel-in-progress: false` to queue (not cancel) overlapping runs
2. Pin to `@v6.0.0` to avoid v6.1.0 bug where the action fails to find existing draft releases and creates duplicates

## Review & Testing Checklist for Human

- [ ] Verify [release-drafter#1425](https://github.com/release-drafter/release-drafter/issues/1425) is still open before merging
- [ ] After merging, test by merging 2-3 PRs in quick succession and verify all appear in the draft release

### Notes

- Same fix already applied to `airbyte-ops-mcp` and `awesome-python-template` repos
- Requested by: AJ Steers (@aaronsteers)
- Link to Devin run: https://app.devin.ai/sessions/0dafc41101d144fe975937184b356eb3